### PR TITLE
Fix/measure abundance

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ The **GECKO** toolbox is a Matlab/Python package for enhancing a **G**\ enome-sc
 - ``geckomat``: Matlab+Python scripts to fetch online data and build/simulate enzyme-constrained models.
 - ``geckopy``: a Python package which can be used with `cobrapy <https://opencobra.github.io/cobrapy/>`_ to obtain a ecYeastGEM model object, optionally adjusted for provided proteomics data.
 
-Last update: 2018-11-02
+Last update: 2018-11-26
 
 This repository is administered by Benjamin J. Sanchez (`@BenjaSanchez <https://github.com/benjasanchez>`_), Division of Systems and Synthetic Biology, Department of Biology and Biological Engineering, Chalmers University of Technology.
 
@@ -45,7 +45,7 @@ Usage
 
   - Update the following data files in ``/databases`` with your organism infomation:
   
-    - ``databases/prot_abundance.txt``: Protein abundance Data from Pax-DB.
+    - ``databases/prot_abundance.txt``: Protein abundance Data from Pax-DB. If data is not available for your organism, then a relative proteomics dataset (in molar fractions) can be used instead. The file should be added to the folder ``databases`` and being named as ``relative_proteomics.txt`` , the required format is a tab-separated file with a single header line and 2 columns; the first with gene IDs and the second with the relative abundances for each protein. 
     - ``databases/uniprot.tab``: Gene-proteins data from uniprot.
     - ``databases/chemostatData.tsv``: Chemostat data for estimating GAM (optional, called by ``fitGAM.m``).
     - ``databases/manual_data.txt``: Kcat data from eventual manual curations (optional, called by ``manualModifications.m``).

--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ Usage
 
   - Update the following data files in ``/databases`` with your organism infomation:
   
-    - ``databases/prot_abundance.txt``: Protein abundance Data from Pax-DB. If data is not available for your organism, then a relative proteomics dataset (in molar fractions) can be used instead. The file should be added to the folder ``databases`` and being named as ``relative_proteomics.txt`` , the required format is a tab-separated file with a single header line and 2 columns; the first with gene IDs and the second with the relative abundances for each protein. 
+    - ``databases/prot_abundance.txt``: Protein abundance Data from Pax-DB. If data is not available for your organism, then a relative proteomics dataset (in molar fractions) can be used instead. The required format is a tab-separated file, named as ``databases/relative_proteomics.txt`` , with a single header line and 2 columns; the first with gene IDs and the second with the relative abundances for each protein. 
     - ``databases/uniprot.tab``: Gene-proteins data from uniprot.
     - ``databases/chemostatData.tsv``: Chemostat data for estimating GAM (optional, called by ``fitGAM.m``).
     - ``databases/manual_data.txt``: Kcat data from eventual manual curations (optional, called by ``manualModifications.m``).

--- a/geckomat/limit_proteins/measureAbundance.m
+++ b/geckomat/limit_proteins/measureAbundance.m
@@ -2,51 +2,74 @@
 % [f,count] = measureAbundance(enzymes)
 % 
 % Benjamin J. Sanchez. Last edited: 2018-08-10
+% Ivan Domenzain.      Last edited: 2018-11-26
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
 function [f,count] = measureAbundance(enzymes)
-
+genes     = {};
+abundance = [];
 %Read downloaded data of abundance:
-fID       = fopen('../../databases/prot_abundance.txt');
-data      = textscan(fID,'%s %s %f','delimiter','\t','HeaderLines',12);
-genes     = data{2};
-genes     = strrep(genes,'4932.','');
-abundance = data{3};
-fclose(fID);
-
-%Load swissprot data:
-data      = load('../../databases/ProtDatabase.mat');
-swissprot = data.swissprot;
-for i = 1:length(swissprot)
-    swissprot{i,3} = strsplit(swissprot{i,3},' ');
+%Count number of header lines
+fileName = '../../databases/prot_abundance.txt';
+if exist(fileName,'file')~= 0
+    fID         = fopen('../../databases/prot_abundance.txt');
+    data        = textscan(fID,'%s','delimiter','\n');
+    headerLines = sum(startsWith(data{1},'#'));
+    fclose(fID);
+    %Read data file, excluding headerlines
+    fID         = fopen('../../databases/prot_abundance.txt');
+    data        = textscan(fID,'%s %s %f','delimiter','\t','HeaderLines',headerLines);
+    genes       = data{2};
+    %Remove internal geneIDs modifiers
+    genes     = regexprep(genes,'(\d{4}).','');
+    abundance = data{3};
+    fclose(fID);
+else
+    fileName = '../../databases/relative_proteomics.txt';
+    if exist(fileName,'file')~= 0
+        fID       = fopen(fileName);
+        data      = textscan(fID,'%s %f','delimiter','\t','HeaderLines',1);
+        genes     = data{1};
+        abundance = data{2};
+    end
 end
 
-%Main loop:
-MW_ave  = mean(cell2mat(swissprot(:,5)));
-concs   = zeros(size(genes));
-counter = false(size(genes));
-for i = 1:length(genes)
-    MW = MW_ave;
-    %Find gene in swissprot database:
-    for j = 1:length(swissprot)
-        if sum(strcmp(swissprot{j,3},genes{i})) > 0
-            MW = swissprot{j,5};	%g/mol
-            %Check if uniprot is in model:
-            if sum(strcmp(enzymes,swissprot{j,1})) > 0
-                counter(i) = true;
+if ~isempty(genes)
+    %Load swissprot data:
+    data      = load('../../databases/ProtDatabase.mat');
+    swissprot = data.swissprot;
+    for i = 1:length(swissprot)
+        swissprot{i,3} = strsplit(swissprot{i,3},' ');
+    end
+
+    %Main loop:
+    MW_ave  = mean(cell2mat(swissprot(:,5)));
+    concs   = zeros(size(genes));
+    counter = false(size(genes));
+    for i = 1:length(genes)
+        MW = MW_ave;
+        %Find gene in swissprot database:
+        for j = 1:length(swissprot)
+            if sum(strcmp(swissprot{j,3},genes{i})) > 0
+                MW = swissprot{j,5};	%g/mol
+                %Check if uniprot is in model:
+                if sum(strcmp(enzymes,swissprot{j,1})) > 0
+                    counter(i) = true;
+                end
             end
         end
+        concs(i) = MW*abundance(i);     %g/mol(tot prot)
+        if rem(i,100) == 0
+            disp(['Calculating total abundance: Ready with ' num2str(i) '/' ...
+                  num2str(length(genes)) ' genes '])
+        end
     end
-    concs(i) = MW*abundance(i);     %g/mol(tot prot)
-    if rem(i,100) == 0
-        disp(['Calculating total abundance: Ready with ' num2str(i) '/' ...
-              num2str(length(genes)) ' genes '])
-    end
+    f     = sum(concs(counter))/sum(concs);
+    count = [length(counter);sum(counter)];
+else
+    disp('prot_abundance file is not available. A default value of f=0.5 is set instead')
+    f     = 0.5;
+    count = 0;
+end
 end
 
-f     = sum(concs(counter))/sum(concs);
-count = [length(counter);sum(counter)];
-
-end
-
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
Generalization of the function ``measureAbundance.m``:

- A PaxDB file for any organism can be read properly by the function.
- If PaxDB data is not available a relative proteomics dataset (in molar fractions) can be used instead.
- If none of this files is detected, then a default value of f=0.5 is set instead.