### PR TITLE
refactor/feat: topUsedEnzymes, truncateValues and modifyKcats

### DIFF
--- a/geckomat/kcat_sensitivity_analysis/modifyKcats.m
+++ b/geckomat/kcat_sensitivity_analysis/modifyKcats.m
@@ -68,7 +68,7 @@ if ~isempty(changes)
     varNamesTable = {'Unicode','enz_pos','rxn_pos','Organism','Modified',...
                     'Parameter','oldValue','newValue','error','ControlCoeff'};  
     changes = cell2table(changes,'VariableNames',varNamesTable);
-    changes = truncateValues(changes,4);
+    changes = truncateValues(changes,[7:10]);
     %Write results in a .txt for further exploration.
     writetable(changes,['../../models/' name '/' name '_kcatModifications.txt']);
 else
@@ -81,13 +81,13 @@ else
     if ~isempty(limRxns)
         varNamesTable = {'rxnNames','rxnPos','ControlCoeff'};
         changes = cell2table(limRxns,'VariableNames',varNamesTable);
-        changes = truncateValues(changes,4);
+        changes = truncateValues(changes,3);
         writetable(changes,['../../models/' name '/' name '_limitingRxns.txt']);
     end
     if ~isempty(limEnz)
         varNamesTable = {'EnzNames','EnzPos','ControlCoeff'};
         changes = cell2table(limEnz,'VariableNames',varNamesTable);
-        changes = truncateValues(changes,4);
+        changes = truncateValues(changes,3);
         writetable(changes,['../../models/' name '/' name '_limitingEnzymes.txt']);
     end
 end

--- a/geckomat/kcat_sensitivity_analysis/topUsedEnzymes.m
+++ b/geckomat/kcat_sensitivity_analysis/topUsedEnzymes.m
@@ -1,24 +1,30 @@
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-% function T = topUsedEnzymes(fluxes,model,conditions,name,writeFile,n)
+function T = topUsedEnzymes(fluxes,model,conditions,name,writeFile,n)
+% topUsedEnzymes
 %
-% Function that gets an ecModel_batch and a matrix of pFBA solution vectors
-% and calculate the top ten enzyme usages for every solution (conditions)
-% in a mass-wise way. The results are written in the topUsedEnzymes.txt
-% file and stored in the container folder.
+%   Function that gets an ecModel_batch and a matrix of FBA solution vectors
+%   and calculate the top ten enzyme usages for every solution (conditions)
+%   in a mass-wise way. The results are written in the topUsedEnzymes.txt
+%   file and stored in the container folder.
 %
-%   fluxes      cell array with pFBA solution vectors
-%   model       ecGEM structure used to generate pFBA solution vectors
-%   conditions  cell array of strings, with names identifying each pFBA
+%   fluxes      matrix with FBA solution vectors 
+%               [# Rxns in model, # simulated conditions]
+%   model       ecGEM structure used to generate FBA solution vectors
+%   conditions  cell array of strings, with names identifying the conditions
+%               for each solution vector
 %               solution vector
 %   name        string with model abbreviation (opt, default 'ecModel')
 %   writeFile   logical, whether a file should be written at the location
 %               gecko/models/'name' (opt, default true)
 %   n           number of top used enzymes to be listed. (opt, default 10)
 %
-% Ivan Domenzain    Last edited 2018-09-25
-% Eduard Kerkhoven  Last edited 2018-12-05
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-function T = topUsedEnzymes(fluxes,model,conditions,name,writeFile,n)
+%   T           Table including the top "n" used proteins (names and usages)
+%               for each specified condition
+%
+%   Usage: T = topUsedEnzymes(fluxes,model,conditions,name,writeFile,n)
+% 
+%   Ivan Domenzain    Last edited 2018-12-05
+%   Eduard Kerkhoven  Last edited 2018-12-05
+%
 
 if nargin < 6
     n = 10;
@@ -26,12 +32,18 @@ end
 if nargin < 5
     writeFile = true;
 end
-% Find the enzyme usage reactions
-usages = find(~cellfun(@isempty,strfind(model.rxnNames,'prot_')));
+%Find the enzyme usage reactions
+usages = find(~cellfun(@isempty,strfind(model.rxns,'prot_')));
+%Exclude protein pool exchange reaction
 usages = usages(1:end-1);
+%Avoid exceeding vector dimension
+if n>length(usages)
+    n=length(usages);
+end
 usages = fluxes(usages,:);
 [~, nConds] = size(usages);
-outputFile = cell(n,3*nConds);
+outputFile  = cell(n,2*nConds);
+colNames    = cell(1,2*nConds);
 
 for i=1:length(usages(1,:))
     %Units conversion [mmol/gDwh] -> [g prot/gDwh]
@@ -43,16 +55,19 @@ for i=1:length(usages(1,:))
     enzNames = model.enzymes(Indexes);
     enzUsage = enzUsage(1:n);
     enzNames = enzNames(1:n);
-    outputFile(:,(3*i)-2)   = enzNames;
-    outputFile(:,(3*i)-1)   = num2cell(enzUsage);
-    outputFile(:,(3*i))     = conditions(i);
+    outputFile(:,(2*i)-1) = enzNames;
+    outputFile(:,(2*i))   = num2cell(enzUsage);
+    %Create column names for output table/file
+    colNames(1,(2*i)-1)   = strcat('prots_',conditions(i));
+    colNames(1,(2*i))     = strcat('Usages_',conditions(i));
 end
 %Write the top-ten used enzyme names and their percentage usages for
 %every condition on the output file
 i=1:length(usages(1,:));
-i=(3*i)-1;
+i=(2*i);
 outputFile = truncateValues(outputFile,i);
+T = cell2table(outputFile,'VariableNames',colNames);
 if writeFile
-    writetable(cell2table(outputFile),['../../models/' name '/' name '_topUsedEnzymes.txt'])
+    writetable(T,['../../models/' name '/' name '_topUsedEnzymes.txt'])
 end
 end

--- a/geckomat/kcat_sensitivity_analysis/topUsedEnzymes.m
+++ b/geckomat/kcat_sensitivity_analysis/topUsedEnzymes.m
@@ -1,42 +1,58 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-% function T = topUsedEnzymes(fluxes,model,conditions,name)
+% function T = topUsedEnzymes(fluxes,model,conditions,name,writeFile,n)
 %
-% Function that gets an ecModel_batch and a matrix of pFBA solution vectors 
+% Function that gets an ecModel_batch and a matrix of pFBA solution vectors
 % and calculate the top ten enzyme usages for every solution (conditions)
 % in a mass-wise way. The results are written in the topUsedEnzymes.txt
 % file and stored in the container folder.
 %
-% Ivan Domenzain    Last edited. 2018-09-25
+%   fluxes      cell array with pFBA solution vectors
+%   model       ecGEM structure used to generate pFBA solution vectors
+%   conditions  cell array of strings, with names identifying each pFBA
+%               solution vector
+%   name        string with model abbreviation (opt, default 'ecModel')
+%   writeFile   logical, whether a file should be written at the location
+%               gecko/models/'name' (opt, default true)
+%   n           number of top used enzymes to be listed. (opt, default 10)
+%
+% Ivan Domenzain    Last edited 2018-09-25
+% Eduard Kerkhoven  Last edited 2018-12-05
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-function topUsedEnzymes(fluxes,model,conditions,name)
-    Indexes    = [];
-    varNames   = {};
-    outputFile = table;
-    % Find the enzyme usage reactions
-    usages = find(~cellfun(@isempty,strfind(model.rxnNames,'prot_')));
-    usages = usages(1:end-1);
-    usages = fluxes(usages,:);
+function T = topUsedEnzymes(fluxes,model,conditions,name,writeFile,n)
 
-    for i=1:length(usages(1,:))
-        %Units conversion [mmol/gDwh] -> [g prot/gDwh]
-        enzUsage{i} = usages(:,i).*model.MWs;
-        %Get the mass fraction of the proteome for every protein in the mod
-        enzUsage{i} = enzUsage{i}/sum(enzUsage{i}); 
-        %Sort and keep the top ten used enzymes
-        [enzUsage{i},Indexes{i}] = sort( enzUsage{i},'descend');
-         enzNames{i} = model.enzymes(Indexes{i});
-         enzUsage{i} = (enzUsage{i}(1:10));
-         enzNames{i} = enzNames{i}(1:10);
-         for j=1:10
-             outputFile(j,(2*i)-1) = enzNames{i}(j); 
-             outputFile(j,(2*i))   = {enzUsage{i}(j)};
-             varNames              = [varNames conditions(i)];
-         end
-    end
-    %Write the top-ten used enzyme names and their percentage usages for
-    %every condition on the output file
-    outputFile = truncateValues(outputFile,1);
-    writetable(outputFile,['../../models/' name '/' name '_topUsedEnzymes.txt'])
+if nargin < 6
+    n = 10;
 end
+if nargin < 5
+    writeFile = true;
+end
+% Find the enzyme usage reactions
+usages = find(~cellfun(@isempty,strfind(model.rxnNames,'prot_')));
+usages = usages(1:end-1);
+usages = fluxes(usages,:);
+[~, nConds] = size(usages);
+outputFile = cell(n,3*nConds);
 
-
+for i=1:length(usages(1,:))
+    %Units conversion [mmol/gDwh] -> [g prot/gDwh]
+    enzUsage = usages(:,i).*model.MWs;
+    %Get the mass fraction of the proteome for every protein in the mod
+    enzUsage = enzUsage/sum(enzUsage);
+    %Sort and keep the top ten used enzymes
+    [enzUsage,Indexes] = sort(enzUsage,'descend');
+    enzNames = model.enzymes(Indexes);
+    enzUsage = enzUsage(1:n);
+    enzNames = enzNames(1:n);
+    outputFile(:,(3*i)-2)   = enzNames;
+    outputFile(:,(3*i)-1)   = num2cell(enzUsage);
+    outputFile(:,(3*i))     = conditions(i);
+end
+%Write the top-ten used enzyme names and their percentage usages for
+%every condition on the output file
+i=1:length(usages(1,:));
+i=(3*i)-1;
+outputFile = truncateValues(outputFile,i);
+if writeFile
+    writetable(cell2table(outputFile),['../../models/' name '/' name '_topUsedEnzymes.txt'])
+end
+end

--- a/geckomat/kcat_sensitivity_analysis/truncateValues.m
+++ b/geckomat/kcat_sensitivity_analysis/truncateValues.m
@@ -1,19 +1,21 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-% table = truncateValues(table,nCols)
-%
+% table = truncateValues(table,cols)
+%   table   cell array or table where some columns have values that should
+%           be truncated
+%   cols    index or indices of columns with values to be truncated
 %
 % Benjamin Sanchez    Last edited: 2018-05-25
+% Eduard Kerkhoven    Last edited: 2018-12-05
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-function table = truncateValues(table,nCols)
+function table = truncateValues(table,cols)
 
 [m,n] = size(table);
 for i = 1:m
-    for j = (n-nCols+1):n
+    for j = cols
         orderMagn  = max([ceil(log10(abs(table{i,j}))),0]);
         table{i,j} = round(table{i,j},6-orderMagn);
     end
 end
-
 end
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/geckomat/limit_proteins/getConstrainedModel.m
+++ b/geckomat/limit_proteins/getConstrainedModel.m
@@ -61,7 +61,7 @@ function [ecModel_batch,OptSigma] = getConstrainedModel(ecModel,c_source,sigma,P
         %enzymes to the file "topUsedEnzymes.txt" in the containing folder
         [ecModel_batch,~] = changeMedia_batch(ecModel_batch,c_source,'Min');
         solution          = solveLP(ecModel_batch,1);
-        topUsedEnzymes(solution.x,ecModel_batch,'Min_glucose',name);
+        topUsedEnzymes(solution.x,ecModel_batch,{'Min_glucose'},name);
         cd ../limit_proteins
     else
         disp('ecModel with enzymes pool constraint is not feasible')


### PR DESCRIPTION
- doc:
  - explanation of input parameters
- refactor:
  - `topUsedEnzymes`only generate table from cell array near end of function, for speed improvement and getting rid of warnings when new data was added to the table
- feat:
  - `topUsedEnzymes` optional parameters: `writeFile` and `n` for number of top used enzymes, and now supporting `T` as command line output
  - `topUsedEnzymes` output table now contains additional column specifying the condition, this changes the output from before this commit
  - `truncateValues` directly uses column numbers: instead of `nCols` referring to last number of columns, `cols` now contains directly which columns should have their value truncated.
- fix:
  - `modifyKcats` supports new `truncateValues` behaviour