### PR TITLE
Fix/comparative_FVA

### DIFF
--- a/geckomat/utilities/FVA/comparativeFVA.m
+++ b/geckomat/utilities/FVA/comparativeFVA.m
@@ -128,7 +128,7 @@ else
 end
 
 model.lb(objIndx) = factor*priorValue;
-model.ub(objIndx) = priorValue;
+model.ub(objIndx) = 1.0001*priorValue;
 
 sol = solveLP(model);
 if ~isempty(sol.f)


### PR DESCRIPTION
Additional changes and fixes have been introduced to the comparative FVA algorithm:

1. Simplification of `model` and `ecModel` constraining procedure.
2. For reversible reactions, backward reactions are completely blocked when the correspondent forward reaction is being optimized and vice versa.
3. For the batch option,`Model` and `ecModel` can be constrained with the same suboptimal growth rate or with their correspondent optimal values.

These changes were introduced to perform flux variability analysis on 11 human cancer cell-lines models with enzyme constraints. Models, scripts and results available at:
https://github.com/SysBioChalmers/EnzymeConstrained_humanModels