### PR TITLE
fix: change UB only if flexibilized > measured

### DIFF
--- a/geckomat/limit_proteins/flexibilizeProteins.m
+++ b/geckomat/limit_proteins/flexibilizeProteins.m
@@ -149,7 +149,7 @@ for i=1:length(protIndxs)
     %If protein was flexibilized set its upper bound to the simulated
     %concentration
     if ismember(name,flexProts)
-        if optSolution(index)>0 && optSolution(index)>abundances(i)
+        if optSolution(index)>abundances(i)
             model.ub(index) = optSolution(index);
         else
             model.ub(index) = abundances(i);

--- a/geckomat/limit_proteins/flexibilizeProteins.m
+++ b/geckomat/limit_proteins/flexibilizeProteins.m
@@ -149,7 +149,7 @@ for i=1:length(protIndxs)
     %If protein was flexibilized set its upper bound to the simulated
     %concentration
     if ismember(name,flexProts)
-        if optSolution(index)>0
+        if optSolution(index)>0 && optSolution(index)>abundances(i)
             model.ub(index) = optSolution(index);
         else
             model.ub(index) = abundances(i);


### PR DESCRIPTION
I encountered the following case:
1. `flexibilizeProteins` releases the UB of 13 proteins. Protein X is the 8th protein flexibilized.
2. When `getNewBounds` is run as part of `flexibilizeProteins`, the flux through prot_X_exchange is *lower* than the measured abundance. It seems that flexibilization of proteins 9-13 _after_ protein X make protein X no longer limiting the growth.
3. `getNewBounds` then sets the UB of flexibilized proteins to the value that is reached when the completely flexibilized model is simulated. In the case of protein X, this value is lower than the measured abundance, but the UB is still set to this value.
4. While this would not be desired (discarding the measured abundance even when not required), by itself it does not cause any problem (the model should still solve), ...
5. .... *however*, in the case I encountered the flexibilized flux was in the order of e-12, which caused problems with the solver, so the resulting model could not be solved.

In this PR, the UB of a flexibilized protein exchange reaction is only changed if the post-flexibilized model still requires this protein to be flexibilized. Otherwise, the measured abundance is kept.