### PR TITLE
fix: create folder for ecModel files

### DIFF
--- a/geckomat/enhanceGEM.m
+++ b/geckomat/enhanceGEM.m
@@ -55,8 +55,8 @@ ecModel                 = readKcatData(model_data,kcats);
 [ecModel,modifications] = manualModifications(ecModel);
 
 %create specific subfolder for ecModel files if not present already
-if ~isdir(['../models/' name])
-    mkdir(['../models/' name])
+if ~isdir(['../../models/' name])
+    mkdir(['../../models/' name])
 end
 %Constrain model to batch conditions:
 cd ../limit_proteins

--- a/geckomat/enhanceGEM.m
+++ b/geckomat/enhanceGEM.m
@@ -54,6 +54,10 @@ cd ../change_model
 ecModel                 = readKcatData(model_data,kcats);
 [ecModel,modifications] = manualModifications(ecModel);
 
+%create specific subfolder for ecModel files if not present already
+if ~isdir(['../models/' name])
+    mkdir(['../models/' name])
+end
 %Constrain model to batch conditions:
 cd ../limit_proteins
 [ecModel_batch,OptSigma] = getConstrainedModel(ecModel,modifications,name);

--- a/geckomat/kcat_sensitivity_analysis/modifyKcats.m
+++ b/geckomat/kcat_sensitivity_analysis/modifyKcats.m
@@ -69,7 +69,6 @@ if ~isempty(changes)
     changes = cell2table(changes,'VariableNames',varNamesTable);
     changes = truncateValues(changes,[7:10]);
     %Write results in a .txt for further exploration.
-    mkdir (['../../models/' name]);
     writetable(changes,['../../models/' name '/' name '_kcatModifications.txt']);
 else
     %If the model is not feasible then the analysis is performed in all the 


### PR DESCRIPTION
The storage of `ecModel` output files used to rely on a previously existing destination folder.  In the case of `ecYeastGEM`, a destination folder already exists in the `GECKO` repository, but for newly added cases with a different model name this causes  an error. 

This issue has been partially addressed in #80 by the creation of the subfolder `GECKO/models/name` for any new case with a given ecModel name. However, this bug fix introduced the creation of such subfolder in the first potential saving step, within the function `modifyKcats.m`, which is just called for the iterative kcat curation procedure for overconstrained ecModels. In the case of generated ecModels that are able to reach the provided experimental growth rate without the need of kcats curation the first saving step takes place inside the function `topUsedEnzymes.m`, causing the aforementioned error due to bypass of `modifyKcats.m`. This issue was detected by [PR#26](https://github.com/SysBioChalmers/ecModels/pull/26) in the **ecModels** repository.

As the creation of a destination folder is a general step that does not fit properly within the scope of the functions `modifyKcats.m` and `topUsedEnzymes.m`, the creation of a model name-specific directory is therefore included in  the main function of the pipeline, `enhanceGEM,m`, before the `getConstrainedModel` step.