### PR TITLE
Fix/ec model versioning

### DIFF
--- a/geckomat/change_model/preprocessModel.m
+++ b/geckomat/change_model/preprocessModel.m
@@ -1,22 +1,21 @@
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-% [model,name,version] = preprocessModel(model,name,version)
+function [model,name,modelVer] = preprocessModel(model,name,modelVer)
+%preprocessModel
+%
 % Performs some preliminary modifications to the metabolic model & 
 % retrieves the model's name & version (either by parsing model.id or by
 % asking the user to input it), if they were not already defined.
 %
 % model     A genome-scale model in RAVEN format
 % name      The name of the model (alternatively, an empty string)
-% version   The version of the model (alternatively, an empty string)
+% modelVer  The version of the model (alternatively, an empty string)
 % 
 % model     The processed model
 % name      The resulting name of the model (if not specified before)
-% version   The resulting version of the model (if not specified before)
+% modelVer  The resulting version of the model (if not specified before)
 %
 % Benjamin J. Sanchez. Last edited: 2018-09-01
-% Eduard Kerkhoven. Last edited: 2018-10-16
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% Ivan Domenzin.       Last edited: 2020-10-05
 
-function [model,name,version] = preprocessModel(model,name,version)
 
 %Remove gene rules from pseudoreactions (if any):
 for i = 1:length(model.rxns)
@@ -44,13 +43,13 @@ for i = 1:length(model.rxns)
     end
 end
 
-if isempty(name) && isempty(version) && isfield(model,'id')
+if isempty(name) && isempty(modelVer) && isfield(model,'id')
     try
         id = strsplit(model.id,'_v');
         if length(id) == 2
-            name    = id{1};
-            name    = ['ec' upper(name(1)) name(2:end)];
-            version = id{2};
+            name     = id{1};
+            name     = ['ec' upper(name(1)) name(2:end)];
+            modelVer = id{2};
         end
     catch
         disp('Not possible to parse name & version. Input manually')
@@ -59,8 +58,8 @@ end
 while isempty(name)
     name = input('Please enter the desired ecModel name: ','s');
 end
-while isempty(version)
-    version = input('Please enter the model version: ','s');
+while isempty(modelVer)
+    modelVer = input('Please enter the model version: ','s');
 end
 
 end

--- a/geckomat/change_model/preprocessModel.m
+++ b/geckomat/change_model/preprocessModel.m
@@ -16,7 +16,6 @@ function [model,name,modelVer] = preprocessModel(model,name,modelVer)
 % Benjamin J. Sanchez. Last edited: 2018-09-01
 % Ivan Domenzin.       Last edited: 2020-10-05
 
-
 %Remove gene rules from pseudoreactions (if any):
 for i = 1:length(model.rxns)
     if endsWith(model.rxnNames{i},' pseudoreaction')
@@ -24,17 +23,14 @@ for i = 1:length(model.rxns)
         model.rxnGeneMat(i,:) = zeros(1,length(model.genes));
     end
 end
-
 %Swap direction of only reactions that are defined to only carry negative flux
 to_swap=model.lb < 0 & model.ub == 0;
 model.S(:,to_swap)=-model.S(:,to_swap);
 model.ub(to_swap)=-model.lb(to_swap);
 model.lb(to_swap)=0;
-
 %Delete blocked rxns (LB = UB = 0):
 to_remove = logical((model.lb == 0).*(model.ub == 0));
 model     = removeReactions(model,model.rxns(to_remove),true,true,true);
-
 %Correct rev vector: true if LB < 0 & UB > 0, or it is an exchange reaction:
 model.rev = false(size(model.rxns));
 for i = 1:length(model.rxns)
@@ -43,12 +39,14 @@ for i = 1:length(model.rxns)
     end
 end
 
-if isempty(name) && isempty(modelVer) && isfield(model,'id')
+if isfield(model,'id')
     try
         id = strsplit(model.id,'_v');
-        if length(id) == 2
-            name     = id{1};
-            name     = ['ec' upper(name(1)) name(2:end)];
+        if isempty(name)
+            name = id{1};
+            name = ['ec' upper(name(1)) name(2:end)];
+        end
+        if isempty(modelVer)
             modelVer = id{2};
         end
     catch
@@ -61,7 +59,4 @@ end
 while isempty(modelVer)
     modelVer = input('Please enter the model version: ','s');
 end
-
 end
-
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/geckomat/enhanceGEM.m
+++ b/geckomat/enhanceGEM.m
@@ -1,4 +1,4 @@
-function [ecModel,ecModel_batch] = enhanceGEM(model,toolbox,name,version)
+function [ecModel,ecModel_batch] = enhanceGEM(model,toolbox,name,modelVer)
 % enhanceGEM
 %
 %   Main function for running the GECKO pipeline. It returns an ecModel and
@@ -11,7 +11,7 @@ function [ecModel,ecModel_batch] = enhanceGEM(model,toolbox,name,version)
 %   toolbox     string with the name of the prefered toolbox for model SBML
 %               export (COBRA or RAVEN)
 %   name        Desired name for the ecModel (opt, default '')
-%   version     version of the original GEM (opt, default '')
+%   modelVer    modelVer of the original GEM (opt, default '')
 %
 %
 %   ecModel        an ecModel MATLAB structure suitable for incorporation of   
@@ -20,16 +20,16 @@ function [ecModel,ecModel_batch] = enhanceGEM(model,toolbox,name,version)
 %                  the total protein pool usage pseudoreaction,
 %                  proportional to the measured total protein content (Ptot)
 %
-%   Usage: [ecModel,ecModel_batch] = enhanceGEM(model,toolbox,name,version)
+%   Usage: [ecModel,ecModel_batch] = enhanceGEM(model,toolbox,name,modelVer)
 %
-%   Ivan Domenzain. Last edited: 2019-07-13
+%   Ivan Domenzain. Last edited: 2020-10-05
 %
 
 if nargin < 3
     name    = '';
 end
 if nargin < 4
-    version = '';
+    modelVer = '';
 end
 
 %Convert model to RAVEN for easier visualization later on:
@@ -42,7 +42,7 @@ end
 parameters = getModelParameters;
 %Remove blocked rxns + correct model.rev:
 cd change_model
-[model,name,version] = preprocessModel(model,name,version);
+[model,name,modelVer] = preprocessModel(model,name,modelVer);
 
 %Retrieve kcats & MWs for each rxn in model:
 cd ../get_enzyme_data
@@ -61,8 +61,8 @@ disp(['Sigma factor (fitted for growth on glucose): ' num2str(OptSigma)])
 
 %Save output models:
 cd ../../models
-ecModel = saveECmodel(ecModel,toolbox,name,version);
-ecModel_batch = saveECmodel(ecModel_batch,toolbox,[name '_batch'],version);
+ecModel = saveECmodel(ecModel,toolbox,name,modelVer);
+ecModel_batch = saveECmodel(ecModel_batch,toolbox,[name '_batch'],modelVer);
 cd ../geckomat
 
 end


### PR DESCRIPTION
This PR addresses #112: in order to provide a correct versioning system for ecModel git-readable files, the use of variables called `version` across the toolbox has been substituted by a non-ambiguous variable name in all of the functions that required it (`preprocessModel.m` and `enhanceGEM.m`). Git-readable ecModels files show the correct version of yeastGEM now. 