### PR TITLE
chore: migrate to travis-ci.com

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -112,8 +112,8 @@ Contributors
 
 .. |Current Version| image:: https://badge.fury.io/gh/sysbiochalmers%2Fgecko.svg
    :target: https://badge.fury.io/gh/sysbiochalmers%2Fgecko
-.. |Build Status| image:: https://travis-ci.org/SysBioChalmers/GECKO.svg?branch=master
-   :target: https://travis-ci.org/SysBioChalmers/GECKO
+.. |Build Status| image:: https://travis-ci.com/SysBioChalmers/GECKO.svg?branch=master
+   :target: https://travis-ci.com/SysBioChalmers/GECKO
 .. |PyPI Version| image:: https://badge.fury.io/py/geckopy.svg
    :target: https://badge.fury.io/py/geckopy
 .. |Docs Status| image:: https://readthedocs.org/projects/geckotoolbox/badge/?version=latest

--- a/geckopy/travis_pypi_setup.py
+++ b/geckopy/travis_pypi_setup.py
@@ -58,7 +58,7 @@ def fetch_public_key(repo):
 
     Travis API docs: http://docs.travis-ci.com/api/#repository-keys
     """
-    keyurl = 'https://api.travis-ci.org/repos/{0}/key'.format(repo)
+    keyurl = 'https://api.travis-ci.com/repos/{0}/key'.format(repo)
     errmsg = ("\n\nCould not find public key for repo: {}.\n"
               "Have you already added your GitHub repo to Travis?\n\n").format(repo)
     try:


### PR DESCRIPTION
After #116, the CI suite is now operating at https://travis-ci.com/github/SysBioChalmers/GECKO, so a few changes in the repo were needed to point to the new address.