### PR TITLE
fix: allow empty prot_abundance.txt files

### DIFF
--- a/geckomat/limit_proteins/measureAbundance.m
+++ b/geckomat/limit_proteins/measureAbundance.m
@@ -1,11 +1,15 @@
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-% [f,count] = measureAbundance(enzymes)
-% 
-% Benjamin J. Sanchez. Last edited: 2018-08-10
-% Ivan Domenzain.      Last edited: 2018-11-26
-
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 function [f,count] = measureAbundance(enzymes)
+% measureAbundance
+%
+% Computes the f factor, as a proxy to the mass fraction of proteins accounted 
+% for in an ecModel out of the total protein content in cells. An
+% integrated quantitative proteomics dataset from the https://pax-db.org/
+% database (stored in this toolbox as: 'GECKO/databases/prot_abundance.txt')
+% is used as a comparison basis.
+% 
+% Usage: [f,count] = measureAbundance(enzymes)
+%
+
 genes     = {};
 abundance = [];
 %Read downloaded data of abundance:
@@ -14,16 +18,18 @@ fileName = '../../databases/prot_abundance.txt';
 if exist(fileName,'file')~= 0
     fID         = fopen('../../databases/prot_abundance.txt');
     data        = textscan(fID,'%s','delimiter','\n');
-    headerLines = sum(startsWith(data{1},'#'));
-    fclose(fID);
-    %Read data file, excluding headerlines
-    fID         = fopen('../../databases/prot_abundance.txt');
-    data        = textscan(fID,'%s %s %f','delimiter','\t','HeaderLines',headerLines);
-    genes       = data{2};
-    %Remove internal geneIDs modifiers
-    genes     = regexprep(genes,'(\d{4}).','');
-    abundance = data{3};
-    fclose(fID);
+    if ~isempty(data)
+        headerLines = sum(startsWith(data{1},'#'));
+        fclose(fID);
+        %Read data file, excluding headerlines
+        fID         = fopen('../../databases/prot_abundance.txt');
+        data        = textscan(fID,'%s %s %f','delimiter','\t','HeaderLines',headerLines);
+        genes       = data{2};
+        %Remove internal geneIDs modifiers
+        genes     = regexprep(genes,'(\d{4}).','');
+        abundance = data{3};
+        fclose(fID);
+    end
 else
     fileName = '../../databases/relative_proteomics.txt';
     if exist(fileName,'file')~= 0
@@ -41,7 +47,7 @@ if ~isempty(genes)
     for i = 1:length(swissprot)
         swissprot{i,3} = strsplit(swissprot{i,3},' ');
     end
-
+    
     %Main loop:
     MW_ave  = mean(cell2mat(swissprot(:,5)));
     concs   = zeros(size(genes));
@@ -61,13 +67,13 @@ if ~isempty(genes)
         concs(i) = MW*abundance(i);     %g/mol(tot prot)
         if rem(i,100) == 0 || i == length(genes)
             disp(['Calculating total abundance: Ready with ' num2str(i) '/' ...
-                  num2str(length(genes)) ' genes '])
+                num2str(length(genes)) ' genes '])
         end
     end
     f     = sum(concs(counter),'omitnan')/sum(concs,'omitnan');
     count = [length(counter);sum(counter,'omitnan')];
 else
-    disp('prot_abundance file is not available. A default value of f=0.5 is set instead')
+    disp('prot_abundance file is empty or not available. A default value of f=0.5 is set instead')
     f     = 0.5;
     count = 0;
 end


### PR DESCRIPTION
### Main improvements in this PR:

Allow processing of empty `prot_abundance.txt` files by the `limit_proteins/measureAbundance.m` function, which should return a default **`f=0.5`** value in this case. 

This intends to facilitate the generalization of the automated [ecModels update](https://github.com/MetabolicAtlas/ecModels) by GitHub actions. This issue was pointed out in this [discussion](https://github.com/SysBioChalmers/ecModels/issues/19#issuecomment-748471479).

**I hereby confirm that I have:**

- [x] Tested my code with [all requirements](https://github.com/SysBioChalmers/GECKO) for running GECKO
- [x] Selected `devel` as a target branch (top left drop-down menu)