### PR TITLE
Fix/updates to getSubset_ecModel

### DIFF
--- a/geckomat/utilities/getSubset_ecModel.m
+++ b/geckomat/utilities/getSubset_ecModel.m
@@ -1,5 +1,5 @@
 function small_ecModel = getSubset_ecModel(smallGEM,big_ecModel)
-%getsmall_ecModel
+%getSubset_ecModel
 %  
 % Generate a context-specific ecModel (strain/cell-line/tissue) by mapping 
 % all components in an original context-specific GEM to a general ecModel
@@ -10,9 +10,9 @@ function small_ecModel = getSubset_ecModel(smallGEM,big_ecModel)
 %   smallGEM       Reduced model (subset of the general model) for a
 %                  specific strain (microbes) or cell-line/tissues (mammals)
 % 
-%   ecModel        Enzyme-constrained version of the context-specific model
+%   small_ecModel  Enzyme-constrained version of the context-specific model
 % 
-% usage: small_ecModel = getsmall_ecModel(smallGEM,big_ecModel)
+% usage: small_ecModel = getSubset_ecModel(smallGEM,big_ecModel)
 % 
 
 %If smallGEM is in COBRA format convert to RAVEN-type

--- a/geckomat/utilities/getSubset_ecModel.m
+++ b/geckomat/utilities/getSubset_ecModel.m
@@ -39,8 +39,14 @@ small_ecModel = removeGenes(big_ecModel,toRemove,true,true,true);
 %that are not represented in the context-specific GEM, mostly non gene-associated reactions)
 originalRxns = smallGEM.rxns;
 toKeep       = [];
-for rxn = originalRxns
-    idxs   = find(contains(small_ecModel.rxns,rxn));
+for i = 1:numel(originalRxns)
+    % Add backslashes before all brackets or parentheses for regex.
+    % For example, "my(2)reaction[c]" becomes "my\(2\)reaction\[c\]"
+    rxn = regexprep(originalRxns{i}, '\[|\]|\(|\)', '\\$0');
+    
+    % Find all matches with the pattern: (arm_)rxn(_REV)(No#)
+    pattern = ['(^|^arm_)' rxn '($|No\d+$|_REV($|No\d+$))'];
+    idxs = find(~cellfun(@isempty, regexp(small_ecModel.rxns, pattern)));
     toKeep = [toKeep;idxs];
 end
 %Keep enzyme-related reactions

--- a/geckomat/utilities/getSubset_ecModel.m
+++ b/geckomat/utilities/getSubset_ecModel.m
@@ -36,21 +36,16 @@ big_ecModel.lb(idxs) = 0;
 small_ecModel = removeGenes(big_ecModel,toRemove,true,true,true);
 
 %Remove reactions in excess (all remaining reactions in small_ecModel
-%that are not represented in the context-specific GEM, mostly non gene-associated reactions)
+%that are not represented in the context-specific GEM, mostly non 
+%gene-associated reactions).
+%The ecGEM reaction IDs are trimmed to remove prefix "arm_" and suffixes
+%"_REV" or "No#" (where # is an integer(s)). This yields the reaction IDs
+%of the original model to which they are associated.
 originalRxns = smallGEM.rxns;
-toKeep       = [];
-for i = 1:numel(originalRxns)
-    % Add backslashes before all brackets or parentheses for regex.
-    % For example, "my(2)reaction[c]" becomes "my\(2\)reaction\[c\]"
-    rxn = regexprep(originalRxns{i}, '\[|\]|\(|\)', '\\$0');
-    
-    % Find all matches with the pattern: (arm_)rxn(_REV)(No#)
-    pattern = ['(^|^arm_)' rxn '($|No\d+$|_REV($|No\d+$))'];
-    idxs = find(~cellfun(@isempty, regexp(small_ecModel.rxns, pattern)));
-    toKeep = [toKeep;idxs];
-end
+ecRxns_trim = regexprep(small_ecModel.rxns, '^arm_|No\d+$|_REV($|No\d+$)', '');
+toKeep = find(ismember(ecRxns_trim, originalRxns));
+
 %Keep enzyme-related reactions
-toKeep    = unique(toKeep);
 idxs      = find(startsWith(small_ecModel.rxns,'draw_prot_') | ...
                  ismember(small_ecModel.rxns, strcat('prot_', small_ecModel.enzymes ,'_exchange')) | ...
                  strcmpi(small_ecModel.rxns,'prot_pool_exchange'));

--- a/geckomat/utilities/getSubset_ecModel.m
+++ b/geckomat/utilities/getSubset_ecModel.m
@@ -61,8 +61,7 @@ small_ecModel = removeReactions(small_ecModel,toRemove,true,true);
 %obtain indexes of the enzymes that remain as pseudometabolites  in the
 %reduced network
 enzymes = big_ecModel.enzymes;
-idxs    = cellfun(@(x) find(contains(small_ecModel.mets, x)), enzymes,'UniformOutput',false);
-idxs    = find(~cellfun(@isempty,idxs));
+idxs = find(ismember(strcat('prot_', enzymes), small_ecModel.mets));
 
 %Correct enzyme related fields in order to remove enzymes that were removed
 %from the stoichiometric matrix in the removeGenes step

--- a/geckomat/utilities/getSubset_ecModel.m
+++ b/geckomat/utilities/getSubset_ecModel.m
@@ -51,7 +51,9 @@ for i = 1:numel(originalRxns)
 end
 %Keep enzyme-related reactions
 toKeep    = unique(toKeep);
-idxs      = find(contains(small_ecModel.rxns,'draw_prot_') | strcmpi(small_ecModel.rxns,'prot_pool_exchange'));
+idxs      = find(startsWith(small_ecModel.rxns,'draw_prot_') | ...
+                 ismember(small_ecModel.rxns, strcat('prot_', small_ecModel.enzymes ,'_exchange')) | ...
+                 strcmpi(small_ecModel.rxns,'prot_pool_exchange'));
 toKeep    = [toKeep;idxs];
 toRemove  = setdiff((1:numel(small_ecModel.rxns))',toKeep);
 small_ecModel = removeReactions(small_ecModel,toRemove,true,true);

--- a/geckomat/utilities/getSubset_ecModel.m
+++ b/geckomat/utilities/getSubset_ecModel.m
@@ -23,7 +23,11 @@ end
 %Open all exchanges, this prevents removal of well-conected reactions that
 %are blocked due to the imposed constraints on big_ecModel
 [~,idxs]     = getExchangeRxns(big_ecModel);
-big_ecModel.ub(idxs) = 1000;
+if isfield(big_ecModel, 'annotation') && isfield(big_ecModel.annotation, 'defaultUB')
+    big_ecModel.ub(idxs) = big_ecModel.annotation.defaultUB;
+else
+    big_ecModel.ub(idxs) = 1000;
+end
 big_ecModel.lb(idxs) = 0;
 
 %Identify genes that are not present in smallGEM and remove all other model

--- a/geckomat/utilities/getSubset_ecModel.m
+++ b/geckomat/utilities/getSubset_ecModel.m
@@ -65,12 +65,9 @@ idxs = find(ismember(strcat('prot_', enzymes), small_ecModel.mets));
 
 %Correct enzyme related fields in order to remove enzymes that were removed
 %from the stoichiometric matrix in the removeGenes step
-small_ecModel.enzymes   = small_ecModel.enzymes(idxs);
-small_ecModel.enzNames  = small_ecModel.enzNames(idxs);
-small_ecModel.enzGenes  = small_ecModel.enzGenes(idxs);
-small_ecModel.MWs       = small_ecModel.MWs(idxs);
-small_ecModel.sequences = small_ecModel.sequences(idxs);
-small_ecModel.pathways  = small_ecModel.pathways(idxs);
-small_ecModel.concs     = small_ecModel.concs(idxs);
+f = {'enzymes', 'enzNames', 'enzGenes', 'MWs', 'sequences', 'pathways', 'concs'};
+f = intersect(fieldnames(small_ecModel), f);
+for i = 1:numel(f)
+    small_ecModel.(f{i}) = small_ecModel.(f{i})(idxs);
 end
  


### PR DESCRIPTION
A few changes were made to the `getSubset_ecModel` function to make sure that it runs as expected. I've summarized the changes below with some explanations.

**Function header**: 1b9534b
I just noticed some of the variable names hadn't been updated in the function header, so I corrected those.

**Use default UB**: 11b53a5
I often use a default upper/lower bound of `+/-Inf` rather than `+/-1000` when working with ecGEMs due to numerical solver issues. The function now uses the value from `.annotation.defaultUB` if the field exists in the ecGEM structure.

**Perform exact pattern matching for reactions**: 5c0f5c7; refactored: 6dd91f0
Previously, the code was searching for ecGEM reactions whose names contained any of the `smallGEM` reactions. For example, for `smallGEM` reaction `HMR_1000`, it would find its "EC" versions such as `arm_HMR_1000`, `HMR_1000_REV`, `HMR_1000No1`, etc., depending on the grRule associated with `HMR_1000`.

The problem with this approach is that some reaction names are subsets of others, which will result in erroneous matching. For example, if we were looking for all reactions containing `HMR_1000`, we would also match `HMR_10001`, `HMR_10002`, `HMR_10003`, etc., which are completely different reactions.

To address this, the function identifies the original GEM reaction ID associated with each ecGEM reaction ID by removing the prefix `arm_` and/or suffixes `_REV` or `No#` (where `#` is an integer(s)). For example, `arm_HMR_1000_REVNo14` becomes `HMR_1000`. These trimmed IDs can then be evaulated for exact matches to reaction IDs in `smallGEM` to determine which ecGEM reactions should be retained.

If there are any other modification types that should be matched, then let me know so we can incorporate it into the search pattern.

**More enzyme-related reaction types**: 5e15cd7
I noticed that the function finds reactions matching `draw_prot_XXX` (where XXX is an enzyme ID) and `prot_pool_exchange`, but doesn't match reactions of the form `prot_XXX_exchange` which I see in some ecGEMs. I've updated it so it now detects reactions like `prot_XXX_exchange`, but maybe this is incorrect?

**Exact matching of enzyme pseudometabolites**: ed37ac8
Minor change to match exact pseudometabolite names, such as `prot_XXX`, to avoid accidental substring matching. This is probably not necessary since I doubt the protein IDs have the same problem as the reaction names above, but good to be safe.

**Missing structure field**: 2825b0d
When I was testing the function, it threw an error because the ecGEM I used didn't have the `concs` field. I modified the last part of the code to only edit field names that were present in the ecGEM to avoid this error in the future.


