### PR TITLE
feat: specify carbon source with fermentation data

### DIFF
--- a/Databases/fermentationData.txt
+++ b/Databases/fermentationData.txt
@@ -1,2 +1,2 @@
-Condition	Ptot	D	Glucose [mmol/gDw h]	CO2 production [mmol/gDwh]	Oxygen uptake [mmol/gDwh]	Pyruvate	succinate	Glycerol	Acetate	Ethanol
-Std	0.4228	0.1	1.1	2.7	2.5	8.06E-05	1.00E-05	0.001893379	0.089483471	1.00E-05
+Condition	c_source	Ptot	D	carbon source [mmol/gDw h]	CO2 production [mmol/gDwh]	Oxygen uptake [mmol/gDwh]	Pyruvate	succinate	Glycerol	Acetate	Ethanol
+Std	D-glucose exchange (reversible)	0.4228	0.1	1.1	2.7	2.5	8.06E-05	1.00E-05	0.001893379	0.089483471	1.00E-05

--- a/geckomat/limit_proteins/constrainEnzymes.m
+++ b/geckomat/limit_proteins/constrainEnzymes.m
@@ -36,8 +36,14 @@
 cd ..
 parameters = getModelParameters;
 sigma      = parameters.sigma;
-c_source   = parameters.c_source;
 cd limit_proteins
+if nargin<8
+    c_UptakeExp = []; c_source = [];
+elseif isempty(c_UptakeExp)
+    c_source = [];
+else
+    c_source = parameters.c_source;
+end
 %Compute f if not provided:
 if nargin < 2
     [f,~] = measureAbundance(model.enzymes);
@@ -109,6 +115,7 @@ disp(['Total enzymes not measured = '        num2str(sum(~measured))         ' e
 disp(['Total protein in model = '            num2str(Ptot)                   ' g/gDW'])
 enzUsages = [];
 if nargin > 7
+if nargin > 6
     [tempModel,enzUsages,modifications] = flexibilizeProteins(model,gRate,c_UptakeExp,c_source);
     Pmeasured = sum(tempModel.concs(~isnan(tempModel.concs)));
     model     = updateProtPool(tempModel,Ptot,f*sigma);

--- a/geckomat/limit_proteins/flexibilizeProteins.m
+++ b/geckomat/limit_proteins/flexibilizeProteins.m
@@ -36,7 +36,7 @@ flexProts     = {};
 enzUsages     = [];
 modifications = {};
 %constrain glucose uptake if an experimental measurement is provided
-if nargin > 2
+if nargin > 2 & ~isempty(c_source)
     glucUptkIndx           = strcmp(model.rxnNames,c_source);
     model.ub(glucUptkIndx) = c_UptakeExp;
 end

--- a/geckomat/limit_proteins/updateProtPool.m
+++ b/geckomat/limit_proteins/updateProtPool.m
@@ -20,7 +20,6 @@ if any(isnan(model.concs))
             tempModel = setParam(tempModel,'ub',poolIndex,newPool);
             %As bounds for CUR and growth have already been set, protein
             %pool minimization is set as an objective
-            originalC = model.c;
             tempModel = setParam(tempModel,'obj',poolIndex,-1);
             solution  = solveLP(tempModel);
             if ~isempty(solution.x)
@@ -34,7 +33,6 @@ if any(isnan(model.concs))
                 warning('Unfeasible protein flexibilization')
                 model = setParam(tempModel,'ub',poolIndex,1000);
             end
-            model.c = originalC;
         end
     else
         warning('The total measured protein mass exceeds the total protein content.')

--- a/geckomat/limit_proteins/updateProtPool.m
+++ b/geckomat/limit_proteins/updateProtPool.m
@@ -20,6 +20,7 @@ if any(isnan(model.concs))
             tempModel = setParam(tempModel,'ub',poolIndex,newPool);
             %As bounds for CUR and growth have already been set, protein
             %pool minimization is set as an objective
+            originalC = model.c;
             tempModel = setParam(tempModel,'obj',poolIndex,-1);
             solution  = solveLP(tempModel);
             if ~isempty(solution.x)
@@ -33,6 +34,7 @@ if any(isnan(model.concs))
                 warning('Unfeasible protein flexibilization')
                 model = setParam(tempModel,'ub',poolIndex,1000);
             end
+            model.c = originalC;
         end
     else
         warning('The total measured protein mass exceeds the total protein content.')

--- a/geckomat/utilities/integrate_proteomics/generate_protModels.m
+++ b/geckomat/utilities/integrate_proteomics/generate_protModels.m
@@ -100,6 +100,7 @@ for i=1:length(conditions)
     %and flexibilization
     expData  = [GUR(i),CO2prod(i),OxyUptake(i)];
     flexGUR  = flexFactor*GUR(i);
+    ecModelP = setParam(ecModelP,'ub',positionsEC(1),flexGUR);
     ecModelP = DataConstrains(ecModelP,byProducts,byP_flux(i,:),1.1);
     %Get a temporary model structure with the same constraints to be used
     %for minimal enzyme requirements analysis. For all measured enzymes
@@ -124,7 +125,7 @@ for i=1:length(conditions)
     %Get model with proteomics
     f       = 1; %Protein mass in model/Total theoretical proteome
     disp(['Incorporation of proteomics constraints for ' conditions{i} ' condition'])
-    [ecModelP,usagesT,modificationsT,~,coverage] = constrainEnzymes(ecModelP,f,GAM,Ptot(i),pIDs,abundances,Drate(i),flexGUR);
+    [ecModelP,usagesT,modificationsT,~,coverage] = constrainEnzymes(ecModelP,f,GAM,Ptot(i),pIDs,abundances,Drate(i));
     matchedProteins = usagesT.prot_IDs;
     prot_input = {initialProts filteredProts matchedProteins ecModel.enzymes coverage};
     writeProtCounts(conditions{i},prot_input,name); 

--- a/geckomat/utilities/integrate_proteomics/generate_protModels.m
+++ b/geckomat/utilities/integrate_proteomics/generate_protModels.m
@@ -147,7 +147,10 @@ for i=1:length(conditions)
     addpath('..')
     saveECmodel(ecModelP,'COBRA',name,version);
     rmpath('..')
-    cd ../../geckomat/limit_proteins
+    cd(name)
+    movefile([name, '.txt'], [name, '_', conditions{i}, '.txt']);
+    movefile([name, '.xml'], [name, '_', conditions{i}, '.xml']);
+    cd ../../../geckomat/limit_proteins
     %save .txt file
     writetable(usagesT,['../../models/prot_constrained/' name '/enzymeUsages_' conditions{i} '.txt'],'Delimiter','\t')
     writetable(modificationsT,['../../models/prot_constrained/' name '/modifiedEnzymes_' conditions{i} '.txt'],'Delimiter','\t')

--- a/geckomat/utilities/integrate_proteomics/generate_protModels.m
+++ b/geckomat/utilities/integrate_proteomics/generate_protModels.m
@@ -68,17 +68,8 @@ for i=1:length(conditions)
     initialProts = uniprotIDs;
     absValues    = absValues(grouping(i)+1:end);
     %Filter data
-    %Calculate sample specific f-factor, before filtering data. While there
-    %might be individual proteins with too much variability, this should
-    %not affect f calculation too much, meanwhile ensuring higher coverage.
-    cd ../../limit_proteins
-    f = measureAbundance(ecModel.enzymes,uniprotIDs,mean(abundances,2,'omitnan'));
-    sumP = sum(mean(abundances,2,'omitnan'),'omitnan'); % Sum of unfiltered proteins
-    %Filter proteomics data, to only keep high quality measurements
-    cd ../utilities/integrate_proteomics
     [pIDs, abundances] = filter_ProtData(uniprotIDs,abundances,1.96,true);
     filteredProts      = pIDs;
-    disp(['Filtered out ' num2str(round((1-(numel(pIDs)/numel(uniprotIDs)))*100,1)) '% of protein measurements due to low quality.'])
     cd ..
     %correct oxPhos complexes abundances
     if ~isempty(oxPhos)
@@ -96,20 +87,15 @@ for i=1:length(conditions)
     %rescaled and GAM refitted to this condition.
     %For fitting GAM a functional model is needed therefore an ecModel with
     %total protein pool constraint should be used
-    %Prot_diff = abs(Ptot_model-Ptot(i))/Ptot_model;
-    %if Prot_diff>=0.05
-       %[~,GAM] = scaleBioMass(tempModel,Ptot(i),[],true);
+    Prot_diff = abs(Ptot_model-Ptot(i))/Ptot_model;
+    if Prot_diff>=0.05
+       [~,GAM] = scaleBioMass(tempModel,Ptot(i),[],true);
         %Then the GAM and new biomass composition are set in ecModelP, which 
         %is not functional yet but should be used for incorporation of 
         %proteomics data
-        %ecModelP = scaleBioMass(ecModelP,Ptot(i),GAM,true);
-        %disp(' ')
-    %end
-    %Use ecModel_batch to rescale the biomass and estimate the GAM
-    [~,GAM] = scaleBioMass(tempModel,Ptot(i),[],true);
-    %Rescale the ecModel that will have proteomics integrated and reuse the
-    %GAM calculated above
-    ecModelP = scaleBioMass(ecModelP,Ptot(i),GAM,true);
+        ecModelP = scaleBioMass(ecModelP,Ptot(i),GAM,true);
+        disp(' ')
+    end
     %Block production of non-observed metabolites before data incorporation
     %and flexibilization
     expData  = [GUR(i),CO2prod(i),OxyUptake(i)];
@@ -136,9 +122,9 @@ for i=1:length(conditions)
         enzIndex = find(contains(tempModel.enzymes,matchedEnz{j}));
     end
     %Get model with proteomics
-    sumPfilt = sum(abundances); % Sum of filtered proteins
-    PtotNew=Ptot(i)*(sumPfilt/sumP); % sumPfilt is higher than sumP due to adding of standard deviation and flexilizing because of too low measurement. Scale PtotNew with this ratio. 
-    [ecModelP,usagesT,modificationsT,~,coverage] = constrainEnzymes(ecModelP,f,GAM,PtotNew,pIDs,abundances,Drate(i),flexGUR);
+    f       = 1; %Protein mass in model/Total theoretical proteome
+    disp(['Incorporation of proteomics constraints for ' conditions{i} ' condition'])
+    [ecModelP,usagesT,modificationsT,~,coverage] = constrainEnzymes(ecModelP,f,GAM,Ptot(i),pIDs,abundances,Drate(i),flexGUR);
     matchedProteins = usagesT.prot_IDs;
     prot_input = {initialProts filteredProts matchedProteins ecModel.enzymes coverage};
     writeProtCounts(conditions{i},prot_input,name); 
@@ -155,8 +141,14 @@ for i=1:length(conditions)
         fileFluxes = ['../../models/prot_constrained/' name '/fluxes_Exch_' conditions{i} '.txt'];
         printFluxes(ecModelP,solution.x,true,1E-4,fileFluxes)
     end
-    save(['../../models/prot_constrained/' name '/' name '_' conditions{i} '.mat'],'ecModelP')
-    % save .txt file
+    cd ../change_model
+    [~,~,version] = preprocessModel(ecModelP,'','');
+    cd ../../models/prot_constrained
+    addpath('..')
+    saveECmodel(ecModelP,'COBRA',name,version);
+    rmpath('..')
+    cd ../../geckomat/limit_proteins
+    %save .txt file
     writetable(usagesT,['../../models/prot_constrained/' name '/enzymeUsages_' conditions{i} '.txt'],'Delimiter','\t')
     writetable(modificationsT,['../../models/prot_constrained/' name '/modifiedEnzymes_' conditions{i} '.txt'],'Delimiter','\t')
 end

--- a/geckomat/utilities/integrate_proteomics/generate_protModels.m
+++ b/geckomat/utilities/integrate_proteomics/generate_protModels.m
@@ -19,14 +19,6 @@ function generate_protModels(ecModel,grouping,name,ecModel_batch)
 close all
 current = pwd;
 
-%This funcion allows for flexibilization of protein absolute abundances in 
-%case that ecModelP is not feasible using the automatically flexibilized 
-%data, if flex factor is not specified then a factor of 1 is assumed.
-cd ../..
-parameters = getModelParameters;
-Ptot_model = parameters.Ptot;
-c_source   = parameters.c_source;
-cd(current)
 if nargin<4
     ecModel_batch = [];
 end

--- a/geckomat/utilities/integrate_proteomics/generate_protModels.m
+++ b/geckomat/utilities/integrate_proteomics/generate_protModels.m
@@ -147,9 +147,15 @@ for i=1:length(conditions)
     addpath('..')
     saveECmodel(ecModelP,'COBRA',name,version);
     rmpath('..')
+    %Rename model file names to include conditions{i}
     cd(name)
-    movefile([name, '.txt'], [name, '_', conditions{i}, '.txt']);
-    movefile([name, '.xml'], [name, '_', conditions{i}, '.xml']);
+    fileNames = struct2cell(dir('.'));
+    fileNames = fileNames(1,:);
+    fileNames(cellfun(@isempty, regexp(fileNames, [name, '(\.\w{3})']))) = [];
+    for j = 1:length(fileNames)
+        newFileName = regexprep(fileNames{j},[name, '(\.\w{3})'], [name, '_', conditions{i}, '$1']);
+        movefile(fileNames{j}, newFileName);
+    end
     cd ../../../geckomat/limit_proteins
     %save .txt file
     writetable(usagesT,['../../models/prot_constrained/' name '/enzymeUsages_' conditions{i} '.txt'],'Delimiter','\t')

--- a/geckomat/utilities/integrate_proteomics/load_Prot_Ferm_Data.m
+++ b/geckomat/utilities/integrate_proteomics/load_Prot_Ferm_Data.m
@@ -44,7 +44,7 @@ end
 %Extract observed byProduct names from file
 [~,n] = size(fermData);
 if n>6
-    byProds  = fermData(1,7:end);
+    byProds  = fermData(1,8:end);
     byProds  = strrep(byProds,' (mmol/gDw h)','');
     byProds  = strrep(byProds,' [mmol/gDw h]','');
 else
@@ -52,14 +52,15 @@ else
 end
 fermParameters           = [];
 fermParameters.conds     = fermData(2:end,1);
-fermParameters.Ptot      = str2double(fermData(2:end,2));
-fermParameters.Drate     = str2double(fermData(2:end,3));
-fermParameters.GUR       = str2double(fermData(2:end,4));
-fermParameters.CO2prod   = str2double(fermData(2:end,5));
-fermParameters.OxyUptake = str2double(fermData(2:end,6));
+fermParameters.c_source  = fermData(2:end,2);
+fermParameters.Ptot      = str2double(fermData(2:end,3));
+fermParameters.Drate     = str2double(fermData(2:end,4));
+fermParameters.GUR       = str2double(fermData(2:end,5));
+fermParameters.CO2prod   = str2double(fermData(2:end,6));
+fermParameters.OxyUptake = str2double(fermData(2:end,7));
 fermParameters.byP_flux  = byProds;
 if ~isempty(fermParameters.byP_flux)
-    fermParameters.byP_flux = str2double(fermData(2:end,7:end));
+    fermParameters.byP_flux = str2double(fermData(2:end,8:end));
 end
 end
 

--- a/models/saveECmodel.m
+++ b/models/saveECmodel.m
@@ -55,7 +55,7 @@ if strcmp(toolbox,'COBRA')
     writeCbModel(model_cobra,'sbml',[file_name '.xml']);
     writeCbModel(model_cobra,'text',[file_name '.txt']);
 else
-    exportForGit(model,name,root_name,{'xml','yml','txt','mat'});
+    exportForGit(model,name,root_name,{'xml','yml','txt','mat'},false,false);
 end
 
 %Convert notation "e-005" to "e-05 " in stoich. coeffs. to avoid


### PR DESCRIPTION
When generating multiple proteomics-constrained ec-models with different carbon sources, this currently would require different `getModelParameters.m` and `fermentationData.txt` files. Instead, in this PR:
- the carbon source exchange reaction name is included in `fermentationData.txt`
- `load_Prot_Ferm_Data.m` places this information in `fermParameters.c_source`
- `generate_ProtModels.m` uses the condition specific `fermParameters.c_source` instead of the information from `getModelParameters`. (It does not replace `parameters.c_source` in `getModelParameters`, as the carbon source mentioned here is specific for each proteomics dataset)

- some duplicated code (see line 25-27 and 37-39 in old file) was removed.