### PR TITLE
feat: allow non-default GAM parameters

### DIFF
--- a/geckomat/getModelParameters.m
+++ b/geckomat/getModelParameters.m
@@ -16,6 +16,10 @@ parameters.Ptot = 0.5;      %Assumed constant
 %Minimum growth rate the model should grow at [1/h]
 parameters.gR_exp = 0.41;     %[g/gDw h] 
 
+%Set GAM parameters (optional)
+%parameters.GAM = 100; %Use fixed GAM instead of fitting by fitGAM
+%parameters.maxGAM = 100; %Maximum allowable GAM to be used by fitGAM, default is 100;
+
 %Provide your organism scientific name
 parameters.org_name = 'saccharomyces cerevisiae';
 

--- a/geckomat/limit_proteins/fitGAM.m
+++ b/geckomat/limit_proteins/fitGAM.m
@@ -28,7 +28,12 @@ else
 
     %Load chemostat data:
     fid = fopen('../../databases/chemostatData.tsv','r');
-    exp_data = textscan(fid,'%f32 %f32 %f32 %f32','Delimiter','\t','HeaderLines',1);
+    cSource{1} = fgetl(fid);
+    cSource{2} = regexprep(cSource{1},'.*\t(.*)Uptake.*','$1');
+    if strcmp(cSource{1},cSource{2})
+        error("Cannot recognize headerline of 'chemostatData.tsv'.");
+    end
+    exp_data = textscan(fid,'%f32 %f32 %f32 %f32','Delimiter','\t');
     exp_data = [exp_data{1} exp_data{2} exp_data{3} exp_data{4}];
     fclose(fid);
     
@@ -63,10 +68,10 @@ else
         b(i) = plot(mod_data(:,1),mod_data(:,i+1),'Color',cols(i,:),'LineWidth',2);
         plot(exp_data(:,1),exp_data(:,i+1),'o','Color',cols(i,:),'MarkerFaceColor',cols(i,:))
     end
-    title('GAM fitting for growth on glucose minimal media')
+    title(['GAM fitting for growth on ', cSource{2}])
     xlabel('Dilution rate [1/h]')
     ylabel('Exchange fluxes [mmol/gDWh]')
-    legend(b,'Glucose consumption','O2 consumption','CO2 production','Location','northwest')
+    legend(b,[cSource{2}, ' consumption'],'O2 consumption','CO2 production','Location','northwest')
     hold off
 end
 end

--- a/geckomat/limit_proteins/fitGAM.m
+++ b/geckomat/limit_proteins/fitGAM.m
@@ -20,7 +20,12 @@ else
     if nargin<2
         verbose = true;
     end
-    
+    if isfield(parameters,'maxGAM')
+        maxGAM = parameters.maxGAM;
+    else
+        maxGAM = 100;
+    end
+
     %Load chemostat data:
     fid = fopen('../../databases/chemostatData.tsv','r');
     exp_data = textscan(fid,'%f32 %f32 %f32 %f32','Delimiter','\t','HeaderLines',1);
@@ -32,7 +37,7 @@ else
     
     %GAMs to span:
     fprintf('Estimating GAM...')
-    GAM = 20:5:100;
+    GAM = 20:5:maxGAM;
     
     %1st iteration:
     GAM = iteration(model,GAM,exp_data,verbose);


### PR DESCRIPTION
Fixes #133:
- `getModelParameters` contains the optional `parameters.maxGAM`, which can be used to specify the scanned GAM range (GAM = 20:5:100) in `fitGAM`. If not specified, a maximum GAM of 100 is used by default, as was already the case.
- title and legend of the figure generated by `fitGAM` takes the carbon source from `chemostatData.tsv`