### PR TITLE
feat: ModelAdapter pattern for organism specific parameters and customizations

### DIFF
--- a/GECKOInstaller.m
+++ b/GECKOInstaller.m
@@ -28,8 +28,8 @@ classdef GECKOInstaller
 
         function newPaths = GetFilteredSubPaths(path_, filter_)
             pathSep = pathsep();
-			%Check that there are no semicolons in the path - that will cause 
-			%problems since that is the separator used to separate paths
+			%Check that there are no separators in the path - that will cause 
+            %problems since the separator is used to separate paths in a string
 			if contains(path_, pathSep)
 				error('The path in which GECKO resides may not contain semicolons for this installation to work!');
 			end

--- a/GECKOInstaller.m
+++ b/GECKOInstaller.m
@@ -33,7 +33,7 @@ classdef GECKOInstaller
 				error('The path in which GECKO resides may not contain semicolons for this installation to work!');
 			end
             paths = genpath(path_);
-            splitPaths = strsplit(paths, ';');
+            splitPaths = strsplit(paths, GECKOInstaller.PATH_SEPARATOR);
             %remove the last, it is empty
             splitPaths = splitPaths(1,1:end-1);
             matches = regexp(splitPaths, filter_, 'match');

--- a/GECKOInstaller.m
+++ b/GECKOInstaller.m
@@ -4,19 +4,17 @@ classdef GECKOInstaller
 %   Run GECKOInstaller.install to install (will set up the path in MATLAB)
 %   Run GECKOInstaller.uninstall to clear the path from MATLAB
 %   To install, you first need to cd to the GECKO root.
-%
-% Johan Gustafsson, 2022-07-07
-%
+
     methods (Static)
         function install
             sourceDir = fileparts(which(mfilename));
-            paths = GECKOInstaller.GetFilteredSubPaths(sourceDir, '.*\.git.*');
+            paths = GECKOInstaller.GetFilteredSubPaths(sourceDir, FILE_FILTER);
             addpath(paths);
             savepath;
         end
         function uninstall
             sourceDir = fileparts(which(mfilename));
-            paths = GECKOInstaller.GetFilteredSubPaths(sourceDir, '.*\.git.*');
+            paths = GECKOInstaller.GetFilteredSubPaths(sourceDir, FILE_FILTER);
             rmpath(paths);
             savepath;
         end
@@ -40,4 +38,8 @@ classdef GECKOInstaller
             newPaths = strcat(char(join(pathsLeft,';')),';');
         end
     end
+    
+    properties (Constant)
+      FILE_FILTER = '.*\.git.*';
+   end
 end

--- a/GECKOInstaller.m
+++ b/GECKOInstaller.m
@@ -45,5 +45,6 @@ classdef GECKOInstaller
     
     properties (Constant)
       FILE_FILTER = '.*\.git.*';
+      PATH_SEPARATOR = ';';
    end
 end

--- a/GECKOInstaller.m
+++ b/GECKOInstaller.m
@@ -27,24 +27,24 @@ classdef GECKOInstaller
 		end
 
         function newPaths = GetFilteredSubPaths(path_, filter_)
+            pathSep = pathsep();
 			%Check that there are no semicolons in the path - that will cause 
 			%problems since that is the separator used to separate paths
-			if contains(path_, ';')
+			if contains(path_, pathSep)
 				error('The path in which GECKO resides may not contain semicolons for this installation to work!');
 			end
             paths = genpath(path_);
-            splitPaths = strsplit(paths, GECKOInstaller.PATH_SEPARATOR);
+            splitPaths = strsplit(paths, pathSep);
             %remove the last, it is empty
             splitPaths = splitPaths(1,1:end-1);
             matches = regexp(splitPaths, filter_, 'match');
             okPaths = cellfun(@isempty, matches);
             pathsLeft = splitPaths(1,okPaths);
-            newPaths = strcat(char(join(pathsLeft, GECKOInstaller.PATH_SEPARATOR)), GECKOInstaller.PATH_SEPARATOR);
+            newPaths = strcat(char(join(pathsLeft, pathSep)), pathSep);
         end
     end
     
     properties (Constant)
       FILE_FILTER = '.*\.git.*';
-      PATH_SEPARATOR = ';';
    end
 end

--- a/GECKOInstaller.m
+++ b/GECKOInstaller.m
@@ -39,7 +39,7 @@ classdef GECKOInstaller
             matches = regexp(splitPaths, filter_, 'match');
             okPaths = cellfun(@isempty, matches);
             pathsLeft = splitPaths(1,okPaths);
-            newPaths = strcat(char(join(pathsLeft,';')),';');
+            newPaths = strcat(char(join(pathsLeft, GECKOInstaller.PATH_SEPARATOR)), GECKOInstaller.PATH_SEPARATOR);
         end
     end
     

--- a/GECKOInstaller.m
+++ b/GECKOInstaller.m
@@ -1,0 +1,43 @@
+classdef GECKOInstaller
+% GECKOInstaller
+%   Support for installing and uninstalling
+%   Run GECKOInstaller.install to install (will set up the path in MATLAB)
+%   Run GECKOInstaller.uninstall to clear the path from MATLAB
+%   To install, you first need to cd to the GECKO root.
+%
+% Johan Gustafsson, 2022-07-07
+%
+    methods (Static)
+        function install
+            sourceDir = fileparts(which(mfilename));
+            paths = GECKOInstaller.GetFilteredSubPaths(sourceDir, '.*\.git.*');
+            addpath(paths);
+            savepath;
+        end
+        function uninstall
+            sourceDir = fileparts(which(mfilename));
+            paths = GECKOInstaller.GetFilteredSubPaths(sourceDir, '.*\.git.*');
+            rmpath(paths);
+            savepath;
+        end
+        function path = getGECKOMainPath()
+			path = fileparts(which(mfilename));
+			path = strrep(path, '\', '/'); %get rid of backslashes in Windows
+			if ~endsWith(path, '/')
+				path = strcat(path,'/');
+			end
+		end
+
+        function newPaths = GetFilteredSubPaths(path_, filter_)
+            % Will fail if you have a directory containing ';'
+            paths = genpath(path_);
+            splitPaths = strsplit(paths, ';');
+            %remove the last, it is empty
+            splitPaths = splitPaths(1,1:end-1);
+            matches = regexp(splitPaths, filter_, 'match');
+            okPaths = cellfun(@isempty, matches);
+            pathsLeft = splitPaths(1,okPaths);
+            newPaths = strcat(char(join(pathsLeft,';')),';');
+        end
+    end
+end

--- a/GECKOInstaller.m
+++ b/GECKOInstaller.m
@@ -8,13 +8,13 @@ classdef GECKOInstaller
     methods (Static)
         function install
             sourceDir = fileparts(which(mfilename));
-            paths = GECKOInstaller.GetFilteredSubPaths(sourceDir, FILE_FILTER);
+            paths = GECKOInstaller.GetFilteredSubPaths(sourceDir, GECKOInstaller.FILE_FILTER);
             addpath(paths);
             savepath;
         end
         function uninstall
             sourceDir = fileparts(which(mfilename));
-            paths = GECKOInstaller.GetFilteredSubPaths(sourceDir, FILE_FILTER);
+            paths = GECKOInstaller.GetFilteredSubPaths(sourceDir, GECKOInstaller.FILE_FILTER);
             rmpath(paths);
             savepath;
         end
@@ -27,7 +27,11 @@ classdef GECKOInstaller
 		end
 
         function newPaths = GetFilteredSubPaths(path_, filter_)
-            % Will fail if you have a directory containing ';'
+			%Check that there are no semicolons in the path - that will cause 
+			%problems since that is the separator used to separate paths
+			if contains(path_, ';')
+				error('The path in which GECKO resides may not contain semicolons for this installation to work!');
+			end
             paths = genpath(path_);
             splitPaths = strsplit(paths, ';');
             %remove the last, it is empty

--- a/geckomat/model_adapter/HumanGEMAdapter.m
+++ b/geckomat/model_adapter/HumanGEMAdapter.m
@@ -1,0 +1,53 @@
+classdef HumanGEMAdapter < ModelAdapter 
+    methods
+        function obj = HumanGEMAdapter()
+            %Set initial values of the parameters - they can be changed by the user
+            
+            %these parameters are just copied from getParams in ecModels
+			
+            %Average enzyme saturation factor
+			obj.params.sigma = 0.5;
+
+			%Total protein content in the cell [g protein/gDw]
+			obj.params.Ptot = 0.505717472;  %Average across NCI60 cell lines
+
+			%Minimum growth rate the model should grow at [1/h]
+			obj.params.gR_exp = 0.020663429; %[g/gDw h]/Average across NCI60 cell lines
+
+			%Provide your organism scientific name
+			obj.params.org_name = 'homo sapiens';
+
+			%Provide your organism KEGG ID
+			obj.params.keggID = 'hsa';
+
+			%The name of the exchange reaction that supplies the model with carbon (rxnNames)
+			obj.params.c_source = 'HMR_9034'; 
+
+			%Experimental carbon source uptake (optional)
+			obj.params.c_UptakeExp = 0.641339301; %[mmol/gDw h]/Average across NCI60 cell lines
+
+			%Rxn Id for non-growth associated maitenance pseudoreaction
+			obj.params.NGAM = 'biomass_maintenance_Recon3D'; %this is not used
+
+			%Compartment name in which the added enzymes should be located
+			obj.params.enzyme_comp = 'Cytosol';
+        end
+		
+        function result = getFilePath(obj, filename)
+			result = filename; % TODO: Look at how this should be solved - look at the GeckoLight solution below
+			%result = strcat(GeckoLightInstall.getGeckoLightMainPath(), 'data/humanGEM/', filename);
+		end
+		
+		function [spont,spontRxnNames] = getSpontaneousReactions(obj,model)
+			rxns_tsv = importTsvFile(strcat(getHumanGEMRootPath(),'model/reactions.tsv'));
+			spont = rxns_tsv.spontaneous;
+			spontRxnNames = rxns_tsv.rxns;
+		end
+		
+		function model = manualModifications(obj,model) %default is to do nothing
+			%So, there are some of these in ecModels - it is a bit unclear if any of these are relevant here
+			%we do nothing for now.
+			%In general, manual modifications should be done to the model before sending it in.
+		end
+	end
+end

--- a/geckomat/model_adapter/ModelAdapter.m
+++ b/geckomat/model_adapter/ModelAdapter.m
@@ -1,0 +1,28 @@
+%Abstract Base class for adapters for different species
+classdef (Abstract) ModelAdapter 
+	methods (Abstract)
+        result = getFilePath(obj, filename)
+		[spont,spontRxnNames] = getSpontaneousReactions(obj,model);
+    end
+	methods
+        %not really needed, we could access it directly. Not very nice, but practical
+        function parameters = getParameters(obj)
+            parameters = obj.params;
+        end
+        
+        %This allows for changing parameters in an adapter without 
+        %creating a new class. May be convenient, although less clean
+        %function obj = setParameters(obj, parameters)
+        %    obj.mParams = parameters;
+        %end
+        
+		function model = manualModifications(obj,model) %default is to do nothing
+		end
+    end
+
+    %To have the params public is a bit "ugly", but very practical 
+    %if we want to change a parameter
+    properties (Access = public) 
+        params;
+    end
+end

--- a/geckomat/model_adapter/YeastGEMAdapter.m
+++ b/geckomat/model_adapter/YeastGEMAdapter.m
@@ -1,0 +1,95 @@
+classdef YeastGEMAdapter < ModelAdapter 
+    methods
+        function obj = YeastGEMAdapter()
+            %Set initial values of the obj.params - they can be changed by the user
+            
+            %these paramteres are just copied from getParams in ecModels
+			
+            %Average enzyme saturation factor
+			obj.params.sigma = 0.5;
+
+			%Total protein content in the cell [g protein/gDw]
+			obj.params.Ptot = 0.5;      %Assumed constant
+
+			%Minimum growth rate the model should grow at [1/h]
+			obj.params.gR_exp = 0.41;     %[g/gDw h] 
+
+			%Provide your organism scientific name
+			obj.params.org_name = 'saccharomyces cerevisiae';
+
+			%Provide your organism KEGG ID
+			obj.params.keggID = 'sce';
+
+			%Provide your organism taxonomic ID, will be used to query Uniprot
+			obj.params.taxonID = '559292';
+
+			%The name of the exchange reaction that supplies the model with carbon (rxnNames)
+			obj.params.c_source = 'D-glucose exchange (reversible)'; 
+
+			%Rxn Id for biomass pseudoreaction
+			obj.params.bioRxn = 'r_4041';
+
+			%Rxn Id for non-growth associated maitenance pseudoreaction
+			obj.params.NGAM = 'r_4046';
+
+			%Compartment name in which the added enzymes should be located
+			obj.params.enzyme_comp = 'cytoplasm';
+
+			%Rxn names for the most common experimentally measured "exchange" fluxes
+			%For glucose and o2 uptakes add the substring: " (reversible)" at the end
+			%of the corresponding rxn name. This is due to the irreversible model
+			%nature of ecModels. NOTE: This parameter is only used by fitGAM.m, so if
+			%you do not use said function you don not need to define it.
+			obj.params.exch_names{1} = 'growth';
+			obj.params.exch_names{2} = 'D-glucose exchange (reversible)';
+			obj.params.exch_names{3} = 'oxygen exchange (reversible)';
+			obj.params.exch_names{4} = 'carbon dioxide exchange';
+
+			%Biomass components pseudoreactions (proteins, carbs and lipids lumped
+			%pools). NOTE: This parameter is only used by scaleBioMass.m, so if you do
+			%not use said function you don not need to define it. (optional)
+			obj.params.bio_comp{1} = 'protein';
+			obj.params.bio_comp{2} = 'carbohydrate';
+			obj.params.bio_comp{3} = 'lipid backbone';
+			obj.params.bio_comp{4} = 'lipid chain';
+
+			%Polymerization costs from Forster et al 2003 - table S8. NOTE: This
+			%parameter is only used by scaleBioMass.m, so if you do not use said
+			%function you don not need to define it. (optional)
+			obj.params.pol_cost(1) = 37.7; %Ptot 
+			obj.params.pol_cost(2) = 12.8; %Ctot
+			obj.params.pol_cost(3) = 26.0; %RNA 
+			obj.params.pol_cost(4) = 26.0; %DNA
+
+			%Rxn IDs for reactions in the oxidative phosphorylation pathway (optional)
+			obj.params.oxPhos{1} = 'r_1021';
+			obj.params.oxPhos{2} = 'r_0439';
+			obj.params.oxPhos{3} = 'r_0438';
+			obj.params.oxPhos{4} = 'r_0226';
+
+
+			%TODO: I'm not sure why this param exists for Human-GEM but not for Yeast-GEM - investigate.
+			%Experimental carbon source uptake (optional)
+			%obj.params.c_UptakeExp = 0.641339301; %[mmol/gDw h]/Average across NCI60 cell lines
+        end
+		
+        function result = getFilePath(obj, filename)
+			result = filename; % TODO: Look at how this should be solved - look at the GeckoLight solution below
+			%result = strcat(GeckoLightInstall.getGeckoLightMainPath(), 'data/humanGEM/', filename);
+		end
+		
+		function [spont,spontRxnNames] = getSpontaneousReactions(obj,model)
+			%TODO: I'm not sure if this information exists in Yeast-GEM - if it does, it should be returned in this function
+			%For now, we say none of them are spontaneous.
+			spont = false(length(model.rxns), 1);
+			spontRxnNames = rxns_tsv.rxns;
+			%rxns_tsv = importTsvFile(strcat(getHumanGEMRootPath(),'model/reactions.tsv'));
+			%spont = rxns_tsv.spontaneous;
+		end
+		
+		function model = manualModifications(obj,model) %default is to do nothing
+			%TODO: There are a lot of modifications in the function manualModifications that I suspect are
+			%specific to Yeast-GEM. They should probably be inserted here.
+		end
+	end
+end

--- a/geckomat/model_adapter/getHumanGEMRootPath.m
+++ b/geckomat/model_adapter/getHumanGEMRootPath.m
@@ -1,0 +1,9 @@
+function path = getHumanGEMRootPath()
+	path = fileparts(which('Human-GEM.mat'));%This file should be on the path
+	path = strrep(path, '\', '/'); %get rid of backslashes in Windows
+	if ~endsWith(path, '/')
+		path = strcat(path,'/');
+    end
+    %Now remove the model/ at the end
+    path = (path(1:strlength(path)-6));
+end


### PR DESCRIPTION
### Main improvements in this PR:
Added an adapter pattern that can enable us to use GECKO for different species without copying files. Right now the adapter is pretty small, but the idea is to add more functions in the base class when needed. The idea is then that an adapter is sent into GECKO when generating models, and that GECKO can ask the adapter for information that is accessed differently for each species/model. Examples include parameters, pathways to data, and which reactions are spontaneous. The code is not plugged in anywhere, so this is totally safe.

I also added an installation script, let's see what you think about that. To install (i.e., setup path): 
cd to GECKO root
GECKOInstaller.install
to uninstall (i.e., remove GECKO from path):
GECKOInstaller.uninstall

This is practical if you have several versions of GECKO on your disk and want to switch between them.



**I hereby confirm that I have:**

- [X] Tested my code with [all requirements](https://github.com/SysBioChalmers/GECKO) for running GECKO
- [X] Selected `devel` as a target branch (top left drop-down menu)
