### PR TITLE
fix: use MW/kcat instead of 1/kcat

### DIFF
--- a/geckomat/change_model/applyKcatConstraints.m
+++ b/geckomat/change_model/applyKcatConstraints.m
@@ -49,30 +49,29 @@ if ~model.ec.geckoLight
 end %no clearing needed for GECKO Light, will be overwritten below
 %For normal GECKO formulation (full model), where each enzyme is explicitly considered
 if ~model.ec.geckoLight 
-    %Make vector where column 1 = rxn; 2 = enzyme; 3 = subunit copies; 4 = kcat
-    newKcats=zeros(numel(updateRxns)*10,4);
+    %Column 1 = rxn idx; 2 = enzyme idx; 3 = subunit copies; 4 = kcat; 5 = MW
+    newKcats=zeros(numel(updateRxns)*10,5);
     updateRxns=find(updateRxns);
     kcatFirst=0;
     for i=1:numel(updateRxns)
-        enzymes   = find(model.ec.rxnEnzMat(i,:));
+        j=updateRxns(i);
+        enzymes   = find(model.ec.rxnEnzMat(j,:));
         kcatLast  = kcatFirst+numel(enzymes);
         kcatFirst = kcatFirst+1;
-        newKcats(kcatFirst:kcatLast,1) = updateRxns(i);
+        newKcats(kcatFirst:kcatLast,1) = j;
         newKcats(kcatFirst:kcatLast,2) = enzymes;
-        newKcats(kcatFirst:kcatLast,3) = model.ec.rxnEnzMat(i,enzymes);
-        newKcats(kcatFirst:kcatLast,4) = model.ec.kcat(i);
+        newKcats(kcatFirst:kcatLast,3) = model.ec.rxnEnzMat(j,enzymes);
+        newKcats(kcatFirst:kcatLast,4) = model.ec.kcat(j);
+        newKcats(kcatFirst:kcatLast,5) = model.ec.mw(enzymes);
         kcatFirst = kcatLast;
     end
     newKcats(kcatLast+1:end,:)=[];
     
     sel = newKcats(:,4) ~= 0; %assign zero cost instead of inf when kcat == 0
     newKcats(sel,4) = newKcats(sel,4) * 3600; %per second -> per hour
-    newKcats(sel,4) = newKcats(sel,4).^-1; %Inverse: hours per reaction
-    newKcats(sel,4) = newKcats(sel,4)*1000; %In umol instead of mmol
-    newKcats(sel,4) = newKcats(sel,3).*newKcats(sel,4); %Multicopy subunits.
+    newKcats(sel,4) = newKcats(sel,5) ./ newKcats(sel,4); %MW/kcat
+    newKcats(sel,4) = newKcats(sel,3) .* newKcats(sel,4); %Multicopy subunits.
     newKcats(~sel,4) = 0;
-    %Unit of enzyme usage is umol/gDW/h, while metabolic flux is in mmol/gDW/h.
-    %This prevents very low fluxes.
     
     %Replace rxns and enzymes with their location in model
     [~,newKcats(:,1)] = ismember(model.ec.rxns(newKcats(:,1)),model.rxns);

--- a/geckomat/change_model/makeEcModel.m
+++ b/geckomat/change_model/makeEcModel.m
@@ -179,11 +179,8 @@ ec.concs        = nan(numel(ec.genes),1); % To be filled with proteomics data wh
 if ~geckoLight
     ec.rxnEnzMat = zeros(numel(rxnWithGene),numel(ec.genes)); % Non-zeros will indicate the number of subunits
     for r=1:numel(rxnWithGene)
-        ec.rxns(r) = model.rxns(rxnWithGene(r)); %why is this needed, already set above? Test to remove later
         rxnGenes   = model.genes(find(model.rxnGeneMat(rxnWithGene(r),:)));
         [~,locEnz] = ismember(rxnGenes,ec.genes); % Could also parse directly from rxnGeneMat, but some genes might be missing from Uniprot DB
-        %Changed because this allows for a selection of zero genes - all genes are not always found in 
-        %locEnz = ismember(ec.genes, rxnGenes); % Could also parse directly from rxnGeneMat, but some genes might be missing from Uniprot DB
         if locEnz ~= 0
             ec.rxnEnzMat(r,locEnz) = 1; %Assume 1 copy per subunit or enzyme, can be modified later
         end
@@ -256,7 +253,7 @@ if ~geckoLight
     drawRxns.stoichCoeffs    = cell(numel(drawRxns.rxns),1);
     for i=1:numel(drawRxns.mets)
         drawRxns.mets{i}         = {'prot_pool',proteinMets.mets{i}};
-        drawRxns.stoichCoeffs{i} = [-(ec.mw(uniprotSortId(i)))/1000,1];
+        drawRxns.stoichCoeffs{i} = [-1,1];
     end
     drawRxns.lb              = zeros(numel(drawRxns.rxns),1);
     drawRxns.grRules         = ec.genes(uniprotSortId);


### PR DESCRIPTION
### Main improvements in this PR:
As suggested by @Yu-sysbio, to resolve low fluxes (#147) and have a model formulation that is coherent across full and light GECKO versions, the enzyme usage coefficients are defined as MW/kcat, where MW is given in Dalton (and not kDa).

**I hereby confirm that I have:**

- [ ] Tested my code with [all requirements](https://github.com/SysBioChalmers/GECKO) for running GECKO
- [ ] Selected `devel` as a target branch (top left drop-down menu)
