### PR TITLE
feat: skip making exchange rxns reversible

### DIFF
--- a/src/geckomat/change_model/makeEcModel.m
+++ b/src/geckomat/change_model/makeEcModel.m
@@ -152,7 +152,8 @@ end
 
 %4: Make irreversible model (appends _REV to reaction IDs to indicate reverse
 %reactions)
-model=convertToIrrev(model);
+rxnsWithGenes = sum(model.rxnGeneMat,2);
+model=convertToIrrev(model, model.rxns(logical(rxnsWithGenes)));
 
 %5: Expand model, to separate isoenzymes (appends _EXP_* to reaction IDs to
 %indicate duplication)

--- a/src/geckomat/change_model/makeEcModel.m
+++ b/src/geckomat/change_model/makeEcModel.m
@@ -152,8 +152,10 @@ end
 
 %4: Make irreversible model (appends _REV to reaction IDs to indicate reverse
 %reactions)
-rxnsWithGenes = sum(model.rxnGeneMat,2);
-model=convertToIrrev(model, model.rxns(logical(rxnsWithGenes)));
+[~,exchRxns] = getExchangeRxns(model);
+nonExchRxns = model.rxns;
+nonExchRxns(exchRxns) = [];
+model=convertToIrrev(model, nonExchRxns);
 
 %5: Expand model, to separate isoenzymes (appends _EXP_* to reaction IDs to
 %indicate duplication)


### PR DESCRIPTION
### Main improvements in this PR:
1. When making a new ec-model, currently all reversible reactions are made irreversible.
2. The reason for making irreversible is to avoid negative enzyme usage (or in other words: enzyme pseudometabolites being produced instead of consumed).
3. Only reactions that will be extended with enzyme constraints need to be made irreversible, other reactions (e.g. exchange) do not.
4. Making reactions unnecessarily irreversible results in a larger model with numerous loops.

Therefore, the code here only makes reactions reversible if they are associated to a gene.

Note, #193 should be merged to `devel3` first, after which this PR should be based on `devel3`.

**I hereby confirm that I have:**

- [ ] Tested my code with [all requirements](https://github.com/SysBioChalmers/GECKO) for running GECKO
- [ ] Selected `devel` as a target branch (top left drop-down menu)
