### PR TITLE
Feat: calculate a standard kcat value for missing GPR reactions

### DIFF
--- a/src/geckomat/gather_kcats/getStandardKcat.m
+++ b/src/geckomat/gather_kcats/getStandardKcat.m
@@ -114,6 +114,18 @@ end
 
 model = addGenesRaven(model, proteinStdGenes);
 
+% Add a protein usage reaction
+if ~model.ec.geckoLight
+    proteinStdUsageRxn.rxns            = {'usage_prot_standard'};
+    proteinStdUsageRxn.rxnNames        = proteinStdUsageRxn.rxns;
+    proteinStdUsageRxn.mets         = {'prot_pool', proteinStdMets.mets};
+    proteinStdUsageRxn.stoichCoeffs = [-1, 1];
+    proteinStdUsageRxn.lb              = 0;
+    proteinStdUsageRxn.grRules         = proteinStdGenes.genes;
+    
+    model = addRxns(model, proteinStdUsageRxn);
+end
+
 % Update .ec structure in model
 model.ec.genes(end+1)      = {'standard'};
 model.ec.enzymes(end+1)    = {'standard'};

--- a/src/geckomat/gather_kcats/getStandardKcat.m
+++ b/src/geckomat/gather_kcats/getStandardKcat.m
@@ -23,12 +23,6 @@ function [model, rxnsMissingGPR, standardMW, standardKcat] = getStandardKcat(mod
 %
 %   A pseudometabolite named 'prot_standard' will be added as well as a gene 
 %   and enzyme named 'standard'
-%   
-%   Either all reactions matching the set of proteins will have their kcat
-%   updated. Alternatively, a set of reactions can be defined for specific
-%   changes (e.g. r_0001). Reaction identifiers should be comma separated
-%   (e.g. r_0001, r_0002), and not contain the _REV and/or _EXP_1 suffices
-%   that makeEcModel introduces.
 %
 % Usage:
 %    [model, rxnsMissingGPR, standardMW, standardKcat] = getStandardKcat(model, modelAdapter, threshold);

--- a/src/geckomat/gather_kcats/getStandardKcat.m
+++ b/src/geckomat/gather_kcats/getStandardKcat.m
@@ -1,0 +1,153 @@
+function [model, rxnsMissingGPR, standardMW, standardKcat] = getStandardKcat(model, modelAdapter, threshold)
+% getStandardKcat
+%   Calculate an standard kcat to rxns which a GPR have not been found in the
+%   model
+%
+% Input:
+%   model           an ecModel in GECKO 3 version
+%   modelAdapter    a loaded model adapter (Optional, will otherwise use the
+%                   default model adapter).
+%   threshold     a threshold to determine when use a kcat value based on
+%                      the mean kcat of the reactions in the same subSystem or 
+%                      based on the median value of all the kcat in the
+%                      model. Second option is used when the number of
+%                      reactions in a determined subSystem is < threshold.
+%                      (default = 10)
+%
+% Output:
+%   model          ecModel where kcats for defined proteins have been
+%                       changed
+%   rxnsMissingGPR   a list of update rxns index with a standard value 
+%   standardMW        the standard MW value calculated
+%   standardKcat       the standard Kcat value calculated 
+%
+%   A pseudometabolite named 'prot_standard' will be added as well as a gene 
+%   and enzyme named 'standard'
+%   
+%   Either all reactions matching the set of proteins will have their kcat
+%   updated. Alternatively, a set of reactions can be defined for specific
+%   changes (e.g. r_0001). Reaction identifiers should be comma separated
+%   (e.g. r_0001, r_0002), and not contain the _REV and/or _EXP_1 suffices
+%   that makeEcModel introduces.
+%
+% Usage:
+%    [model, rxnsMissingGPR, standardMW, standardKcat] = getStandardKcat(model, modelAdapter, threshold);
+
+
+if nargin < 2 || isempty(modelAdapter)
+    modelAdapter = ModelAdapterManager.getDefaultAdapter();
+    if isempty(modelAdapter)
+        error('Either send in a modelAdapter or set the default model adapter in the ModelAdapterManager.')
+    end
+end
+
+if nargin < 3
+    threshold = 10;
+end
+
+% Maybe this can be an input ???
+databases = loadDatabases('uniprot', modelAdapter);
+
+% An stardard MW is defined for all the rxns which does not have a GPR
+% rule defined. This is based in all the proteins reported for the specific
+% organism in uniprot
+standardMW = median(databases.uniprot.MW, 'omitnan');
+
+% An standard Kcat is defined for all the rxns which does not have a GPR
+% rule defined. In this case, the kcat value for a particular reaction is
+% defined as the mean of the kcat values of the reactions involved in the
+% same subsystem in which the given reaction is involved. Nevertheless, if
+% a subSystem have a number of reactions lower than a treshold, the kcat
+% value will be the median of the kcat in all the reactions of the model.
+
+% Get the kcat value based on all the kcats in the model
+standardKcat = median(model.ec.kcat, 'omitnan');
+
+enzSubSystems = cell(numel(model.ec.rxns), 1);
+
+% Get the subSystem for the rxns with a GPR
+for i = 1:numel(model.ec.rxns)
+    idx = strcmpi(model.rxns, model.ec.rxns{i});
+    enzSubSystems(i,1) = model.subSystems{idx};
+end
+
+% Remove from the list those with kcat zero
+rxnsKcatZero = model.ec.kcat > 0;
+
+% Determine the subSystems in model.ec
+[enzSubSystem_group, enzSubSystem_names] = findgroups(enzSubSystems(rxnsKcatZero));
+
+% Calculate the mean kcat value for each subSystem in model.ec
+kcatSubSystem = splitapply(@mean, model.ec.kcat(rxnsKcatZero), enzSubSystem_group);
+
+% Calculate the number of reactions for each subSystem in model.ec
+numRxnsSubSystem = splitapply(@numel, model.ec.rxns(rxnsKcatZero), enzSubSystem_group);
+
+% Find subSystems which contains < threshold rxns and assign a standard value
+lowerThanTresh = numRxnsSubSystem < threshold;
+kcatSubSystem(lowerThanTresh) = standardKcat;
+
+% Find reactions without GPR 
+rxnsMissingGPR = find(cellfun(@isempty, model.grRules));
+
+% Get and remove exchange, transport, spontaneous and pseudo reactions
+[~, exchangeRxns]  = getExchangeRxns(model);
+transportRxns = getTransportRxns(model);
+[spontaneousRxns, ~] = modelAdapter.getSpontaneousReactions(model);
+pseudoRxns = contains(model.rxnNames,'pseudoreaction');
+
+rxnsMissingGPR(ismember(rxnsMissingGPR, exchangeRxns)) = [];
+rxnsMissingGPR(ismember(rxnsMissingGPR, find(transportRxns))) = [];
+rxnsMissingGPR(ismember(rxnsMissingGPR, find(spontaneousRxns))) = [];
+rxnsMissingGPR(ismember(rxnsMissingGPR, find(pseudoRxns))) = [];
+
+% Add a new metabolite named prot_standard
+proteinStdMets.mets                = 'prot_standard';
+proteinStdMets.metNames       = proteinStdMets.mets;
+proteinStdMets.compartments = 'c';
+proteinStdMets.metNotes        = 'Standard enzyme-usage pseudometabolite';
+
+model = addMets(model, proteinStdMets);
+
+% Add a new gene to be conssitent with ec field named standard
+proteinStdGenes.genes = 'standard';
+proteinStdGenes.geneShortNames = 'std';
+
+model = addGenesRaven(model, proteinStdGenes);
+
+% Update .ec structure in model
+model.ec.genes(end+1)        = {'standard'};
+model.ec.enzymes(end+1)    = {'standard'};
+model.ec.mw(end+1)            = standardMW;
+model.ec.sequence(end+1)   = {''};
+% Additional info
+model.ec.concs(end+1)        = nan();
+
+% Expand the enzyme rxns matrix
+model.ec.rxnEnzMat =  [model.ec.rxnEnzMat, zeros(length(model.ec.rxns), 1)]; % 1 new enzyme
+model.ec.rxnEnzMat =  [model.ec.rxnEnzMat; zeros(length(rxnsMissingGPR), length(model.ec.enzymes))]; % new rxns
+
+numRxns = length(model.ec.rxns);
+stdMetIdx = find(strcmpi(model.ec.enzymes, 'standard'));
+
+for i = 1:numel(rxnsMissingGPR)
+    rxnIdx = rxnsMissingGPR(i);
+    kcatSubSystemIdx =  strcmpi(enzSubSystem_names, model.subSystems{rxnIdx});
+
+    % Update .ec structure in model
+    model.ec.rxns(end+1)        = model.rxns(rxnIdx);
+    if all(kcatSubSystemIdx)
+        model.ec.kcat(end+1)       = kcatSubSystem(kcatSubSystemIdx);
+    else
+        model.ec.kcat(end+1)       = standardKcat;
+    end
+    model.ec.source(end+1)     = {'Standard kcat'};
+    model.ec.notes(end+1)        = {''};
+    model.ec.eccodes(end+1)   = {''};
+
+    % Update the enzyme rxns matrix
+    model.ec.rxnEnzMat(numRxns+i, stdMetIdx) = 1;
+end
+
+end
+

--- a/src/geckomat/gather_kcats/getStandardKcat.m
+++ b/src/geckomat/gather_kcats/getStandardKcat.m
@@ -55,8 +55,11 @@ standardMW = median(databases.uniprot.MW, 'omitnan');
 % a subSystem have a number of reactions lower than a treshold, the kcat
 % value will be the median of the kcat in all the reactions of the model.
 
+% Remove from the list those with kcat zero
+rxnsKcatZero = model.ec.kcat > 0;
+
 % Get the kcat value based on all the kcats in the model
-standardKcat = median(model.ec.kcat, 'omitnan');
+standardKcat = median(model.ec.kcat(rxnsKcatZero), 'omitnan');
 
 enzSubSystems = cell(numel(model.ec.rxns), 1);
 
@@ -65,9 +68,6 @@ for i = 1:numel(model.ec.rxns)
     idx = strcmpi(model.rxns, model.ec.rxns{i});
     enzSubSystems(i,1) = model.subSystems{idx};
 end
-
-% Remove from the list those with kcat zero
-rxnsKcatZero = model.ec.kcat > 0;
 
 % Determine the subSystems in model.ec
 [enzSubSystem_group, enzSubSystem_names] = findgroups(enzSubSystems(rxnsKcatZero));

--- a/src/geckomat/gather_kcats/getStandardKcat.m
+++ b/src/geckomat/gather_kcats/getStandardKcat.m
@@ -17,7 +17,7 @@ function [model, rxnsMissingGPR, standardMW, standardKcat] = getStandardKcat(mod
 %   model           ecModel where model.ec is expanded with a standard
 %                   protein with standard kcat and standard MW, assigned to
 %                   reactions without gene associations.
-%   rxnsMissingGPR  a list of update rxns index with a standard value
+%   rxnsMissingGPR  a list of updated rxns identifiers with a standard value
 %   standardMW      the standard MW value calculated
 %   standardKcat    the standard Kcat value calculated
 %
@@ -161,4 +161,6 @@ for i = 1:numel(rxnsMissingGPR)
     % Update the enzyme rxns matrix
     model.ec.rxnEnzMat(numRxns+i, stdMetIdx) = 1;
 end
+% Get the rxns identifiers of the updated rxns
+rxnsMissingGPR = model.rxns(rxnsMissingGPR);
 end

--- a/userData/ecHumanGEM/HumanGEMAdapter.m
+++ b/userData/ecHumanGEM/HumanGEMAdapter.m
@@ -99,13 +99,6 @@ classdef HumanGEMAdapter < ModelAdapter
             %Also replace empty strings with something else to avoid matches on empty strings in uniprot
             genes(strcmp(genes, '')) = {'<<<EMPTY>>>'};
         end
-
-        
-		function model = manualModifications(obj,model) %default is to do nothing
-			%So, there are some of these in ecModels - it is a bit unclear if any of these are relevant here
-			%we do nothing for now.
-			%In general, manual modifications should be done to the model before sending it in.
-        end
     end
     
     methods(Static)

--- a/userData/ecYeastGEM/YeastGEMAdapter.m
+++ b/userData/ecYeastGEM/YeastGEMAdapter.m
@@ -112,15 +112,10 @@ classdef YeastGEMAdapter < ModelAdapter
 		function [spont,spontRxnNames] = getSpontaneousReactions(obj,model)
 			%TODO: I'm not sure if this information exists in Yeast-GEM - if it does, it should be returned in this function
 			%For now, we say none of them are spontaneous.
-			spont = false(length(model.rxns), 1);
-			spontRxnNames = rxns_tsv.rxns;
+			spont = contains(model.rxnNames,'spontaneous');
+			spontRxnNames = {''};%rxns_tsv.rxns; For now, create an empty cell
 			%rxns_tsv = importTsvFile(strcat(getHumanGEMRootPath(),'model/reactions.tsv'));
 			%spont = rxns_tsv.spontaneous;
-		end
-		
-		function model = manualModifications(obj,model) %default is to do nothing
-			%TODO: There are a lot of modifications in the function manualModifications that I suspect are
-			%specific to Yeast-GEM. They should probably be inserted here.
 		end
 	end
 end

--- a/userData/yourModel/yourModelAdapter.m
+++ b/userData/yourModel/yourModelAdapter.m
@@ -92,15 +92,10 @@ classdef yourModelAdapter < ModelAdapter
 		function [spont,spontRxnNames] = getSpontaneousReactions(obj,model)
 			%TODO: I'm not sure if this information exists in Yeast-GEM - if it does, it should be returned in this function
 			%For now, we say none of them are spontaneous.
-			spont = false(length(model.rxns), 1);
-			spontRxnNames = rxns_tsv.rxns;
+			spont = contains(model.rxnNames,'spontaneous');
+            spontRxnNames = {''};%rxns_tsv.rxns; For now, create an empty cell
 			%rxns_tsv = importTsvFile(strcat(getHumanGEMRootPath(),'model/reactions.tsv'));
 			%spont = rxns_tsv.spontaneous;
-		end
-		
-		function model = manualModifications(obj,model) %default is to do nothing
-			%TODO: There are a lot of modifications in the function manualModifications that I suspect are
-			%specific to Yeast-GEM. They should probably be inserted here.
 		end
 	end
 end


### PR DESCRIPTION
### Main improvements in this PR:

A standard kcat value is calculate for those reactions with missing GPR, except transport, spontaneous, exchange, and pseduoreactions.

A standard Kcat is defined for all the rxns which does not have a GPR rule defined. In this case, the kcat value for a particular reaction is defined as the mean of the kcat values of the reactions involved in the same subsystem in which the given reaction is involved. Nevertheless, if a subSystem have a number of reactions lower than a treshold, the kcat value will be the median of the kcat in all the reactions of the model.

Additionally, an stardard MW is defined for all the rxns which does not have a GPR rule defined. This is based in all the proteins reported for the specific organism in uniprot

A pseudometabolite named 'prot_standard' will be added as well as a gene and enzyme named 'standard'. 

Function returns the input needed for `applyKcatConstraints`

**I hereby confirm that I have:**

- [x] Tested my code with [all requirements](https://github.com/SysBioChalmers/GECKO) for running GECKO
- [x] Selected `devel` as a target branch (top left drop-down menu)
