### PR TITLE
feat: run DLKcat from a Docker image

### DIFF
--- a/src/geckomat/gather_kcats/runDLKcat.m
+++ b/src/geckomat/gather_kcats/runDLKcat.m
@@ -76,6 +76,7 @@ if ismac && isempty(pythonPath)
             MACZPROFILEPATH = 'set';
         catch
         end
+        setenv('PATH', strcat('/usr/local/bin', ':', getenv("PATH")));
     end
 end
 

--- a/src/geckomat/gather_kcats/runDLKcat.m
+++ b/src/geckomat/gather_kcats/runDLKcat.m
@@ -57,7 +57,7 @@ if ~exist(fullfile(DLKcatPath,'DLKcat.py'),'file')
     packageURL = 'https://github.com/SysBioChalmers/GECKO/raw/dlkcatPackage/dlkcat.zip';
     %packageURL = 'https://github.com/SysBioChalmers/GECKO/releases/download/v3.0.0/dlkcat_package.zip';
     websave(fullfile(DLKcatPath,'dlkcat_package.zip'),packageURL);
-    unzip(fullfile(DLKcatPath,'dlkcat_package.zip'),DLKcatPath);
+    unzip(fullfile(DLKcatPath,'dlkcat_package.zip'),geckoPath);
     delete(fullfile(DLKcatPath,'dlkcat_package.zip'));
 end
 

--- a/src/geckomat/gather_kcats/runDLKcatFromDocker.m
+++ b/src/geckomat/gather_kcats/runDLKcatFromDocker.m
@@ -89,7 +89,7 @@ if checks.image.status == 0 && ~contains(checks.image.out,'dlkcat')
         error('Fail to load the image')
     end
 elseif checks.image.status ~= 0
-    error('Docker is installed. Check if the docker desktop app is running')
+    error('Looks like Docker is installed, but make ensure that the docker desktop app is running.')
 end
 
 % Copy the input file for needed for the docker image to run DLKcat

--- a/src/geckomat/gather_kcats/runDLKcatFromDocker.m
+++ b/src/geckomat/gather_kcats/runDLKcatFromDocker.m
@@ -77,7 +77,7 @@ cd(DLKcatPath);
 if checks.image.status == 0 && ~contains(checks.image.out,'dlkcat')
     % Check if the image file is already dowloaded
     if ~exist(fullfile(DLKcatPath,'dlkcat_docker.tar.gz'),'file')
-        disp('=== Downloading DLKcat docker image, this may take several minutes...')
+        disp('=== Downloading DLKcat docker image, this may take more than 20 minutes, depending on your internet connection speed...')
         packageURL = 'https://github.com/SysBioChalmers/GECKO/raw/dlkcatPackage/dlkcat_docker.tar.gz';
         websave(fullfile(DLKcatPath,'dlkcat_docker.tar.gz'),packageURL);
     end

--- a/src/geckomat/gather_kcats/runDLKcatFromDocker.m
+++ b/src/geckomat/gather_kcats/runDLKcatFromDocker.m
@@ -47,7 +47,7 @@ end
 % On Mac, docker might not be properly loaded if MATLAB is started via
 % launcher and not terminal.
 if ismac
-    setenv('PATH', strcat('/usr/local/bin/', ':', getenv("PATH")));
+    setenv('PATH', strcat('/usr/local/bin', ':', getenv("PATH")));
 end
 
 % Check if docker is installed

--- a/src/geckomat/gather_kcats/runDLKcatFromDocker.m
+++ b/src/geckomat/gather_kcats/runDLKcatFromDocker.m
@@ -1,0 +1,111 @@
+function runDLKcatFromDocker(deleteImage, DLKcatFile, modelAdapter, DLKcatPath)
+% runDLKcatFromDocker
+%   Runs DLKcat to predict kcat values from a Docker image
+%
+% Input
+%   deleteImage      true or false if delete the docker image tar.gz file.
+%                   (Optional, default = false)
+%   DLKcatFile      path to the DLKcat.tsv file (including file name), as
+%                   written by writeDLKcatFile. Once DLKcat is succesfully
+%                   run, the DLKcatFile will be overwritten with the DLKcat
+%                   output. Optional, otherwise the file location will be
+%                   assumed to be in the model-specific 'data' sub-folder
+%                   taken from modelAdapter (e.g.
+%                   GECKO/userData/ecYeastGEM/data/DLKcat.tsv)
+%   modelAdapter    a loaded model adapter. (Optional, will otherwise use
+%                   the default model adapter)
+%   DLKcatPath      path where DLKcat is/will be installed. (Optional,
+%                   defaults to GECKO/dlkcat)
+%
+%   NOTE: 1. Requires Docker to be installed. Visit "https://www.docker.com"
+%         2. Runtime will depend on whether the image is to be downloaded or not.
+
+%Get the GECKO path
+geckoPath = findGECKOroot();
+
+if nargin < 4 || isempty(DLKcatPath)
+    DLKcatPath = fullfile(geckoPath,'dlkcat');
+end
+
+if nargin < 3 || isempty(modelAdapter)
+    modelAdapter = ModelAdapterManager.getDefaultAdapter();
+    if isempty(modelAdapter)
+        error('Either send in a modelAdapter or set the default model adapter in the ModelAdapterManager.')
+    end
+end
+params = modelAdapter.params;
+
+if nargin < 2 || isempty(DLKcatFile)
+    DLKcatFile = fullfile(params.path,'data','DLKcat.tsv');
+end
+
+if nargin < 1 || isempty(DLKcatPath)
+    deleteImage = false;
+end
+
+%% Check and install requirements
+% On Mac, docker might not be properly loaded if MATLAB is started via
+% launcher and not terminal.
+if ismac
+    setenv('PATH', strcat('/usr/local/bin/', ':', getenv("PATH")));
+end
+
+% Check if docker is installed
+[checks.docker.status, checks.docker.out] = system('docker --version');
+if checks.docker.status ~= 0
+    error('Cannot find Docker. Make sure it is installed')
+end
+
+% Dowload DLKcat package
+if ~exist(fullfile(DLKcatPath,'DLKcat.py'),'file')
+    if ~exist(fullfile(DLKcatPath),'dir')
+        mkdir(fullfile(DLKcatPath));
+    end
+    disp('=== Downloading DLKcat ...')
+    packageURL = 'https://github.com/SysBioChalmers/GECKO/raw/dlkcatPackage/dlkcat.zip';
+    %packageURL = 'https://github.com/SysBioChalmers/GECKO/releases/download/v3.0.0/dlkcat_package.zip';
+    websave(fullfile(DLKcatPath,'dlkcat_package.zip'),packageURL);
+    unzip(fullfile(DLKcatPath,'dlkcat_package.zip'),geckoPath);
+    delete(fullfile(DLKcatPath,'dlkcat_package.zip'));
+end
+
+currPath = pwd();
+cd(DLKcatPath);
+
+% First check if the Docker image exist
+[checks.image.status, checks.image.out] = system('docker images');
+if checks.image.status == 0 && ~contains(checks.image.out,'dlkcat')
+    % Check if the image file is already dowloaded
+    if ~exist(fullfile(DLKcatPath,'dlkcat_docker.tar.gz'),'file')
+        disp('=== Downloading DLKcat docker image, this may take several minutes...')
+        packageURL = 'https://github.com/SysBioChalmers/GECKO/raw/dlkcatPackage/dlkcat_docker.tar.gz';
+        websave(fullfile(DLKcatPath,'dlkcat_docker.tar.gz'),packageURL);
+    end
+    [checks.dockerload.status, checks.dockerload.out] = system('docker load --input dlkcat_docker.tar.gz');
+    if deleteImage
+        delete(fullfile(DLKcatPath,'dlkcat_docker.tar.gz'));
+    end
+    if checks.dockerload.status ~= 0
+        error('Fail to load the image')
+    end
+elseif checks.image.status ~= 0
+    error('Docker is installed. Check if the docker desktop app is running')
+end
+
+% Copy the input file for needed for the docker image to run DLKcat
+copyfile(DLKcatFile,fullfile(DLKcatPath, 'data/DLKcat.tsv'));
+
+disp('=== Running DLKcat prediction, this may take several minutes...')
+% In the next line, pythonPath does not need to be specified, because it is
+% already mentioned when building the virtualenv.
+dlkcat.status = system('docker compose -f docker-compose.yaml up dlkcat-cont', '-echo');
+
+if dlkcat.status == 0
+    movefile('data/DLKcatOutput.tsv',DLKcatFile);
+    cd(currPath);
+else
+    cd(currPath);
+    error('DLKcat encountered an error.')
+end
+
+end

--- a/src/geckomat/gather_kcats/runDLKcatFromDocker.m
+++ b/src/geckomat/gather_kcats/runDLKcatFromDocker.m
@@ -17,7 +17,7 @@ function runDLKcatFromDocker(deleteImage, DLKcatFile, modelAdapter, DLKcatPath)
 %   DLKcatPath      path where DLKcat is/will be installed. (Optional,
 %                   defaults to GECKO/dlkcat)
 %
-%   NOTE: 1. Requires Docker to be installed. Visit "https://www.docker.com"
+%   NOTE: 1. Requires Docker to be installed, and docker desktop running. Visit "https://www.docker.com"
 %         2. Runtime will depend on whether the image is to be downloaded or not.
 
 %Get the GECKO path


### PR DESCRIPTION
### Main improvements in this PR:

- Uses a Docker image to run DLKcat in cases `runDLKcat` fails. I test it on my computer so, It would be great if several of you could test it on other computers (MacOS, Windows, and different architecture).

Download the DLKcat can take some time depending of course of the internet speed. It is around 1.9 GB

Docker desktop can be dowloaded from "https://www.docker.com". When running DLKcat docker CLI needs Docker desktop running.

**I hereby confirm that I have:**

- [ ] Tested my code with [all requirements](https://github.com/SysBioChalmers/GECKO) for running GECKO
- [ ] Selected `devel` as a target branch (top left drop-down menu)
