### PR TITLE
Feat: add standard kcats in light version

### DIFF
--- a/src/geckomat/gather_kcats/getStandardKcat.m
+++ b/src/geckomat/gather_kcats/getStandardKcat.m
@@ -65,7 +65,13 @@ enzSubSystems = cell(numel(model.ec.rxns), 1);
 
 % Get the subSystem for the rxns with a GPR
 for i = 1:numel(model.ec.rxns)
-    idx = strcmpi(model.rxns, model.ec.rxns{i});
+    if ~model.ec.geckoLight
+        idx = strcmpi(model.rxns, model.ec.rxns{i});
+    else
+        % Remove prefix
+        rxnId = model.ec.rxns{i}(5:end);
+        idx = strcmpi(model.rxns, rxnId); 
+    end
     % In case there is more than one subSystem select the first one
     if length(model.subSystems{idx}) > 1
         enzSubSystems(i,1) = model.subSystems{idx}(1);
@@ -101,15 +107,17 @@ rxnsMissingGPR(ismember(rxnsMissingGPR, find(transportRxns))) = [];
 rxnsMissingGPR(ismember(rxnsMissingGPR, find(spontaneousRxns))) = [];
 rxnsMissingGPR(ismember(rxnsMissingGPR, find(pseudoRxns))) = [];
 
-% Add a new metabolite named prot_standard
-proteinStdMets.mets         = 'prot_standard';
-proteinStdMets.metNames     = proteinStdMets.mets;
-proteinStdMets.compartments = 'c';
-if isfield(model,'metNotes')
-    proteinStdMets.metNotes     = 'Standard enzyme-usage pseudometabolite';
-end
+% Add a new metabolite named prot_standard if not a light version
+if ~model.ec.geckoLight
+    proteinStdMets.mets         = 'prot_standard';
+    proteinStdMets.metNames     = proteinStdMets.mets;
+    proteinStdMets.compartments = 'c';
+    if isfield(model,'metNotes')
+        proteinStdMets.metNotes     = 'Standard enzyme-usage pseudometabolite';
+    end
 
-model = addMets(model, proteinStdMets);
+    model = addMets(model, proteinStdMets);
+end
 
 % Add a new gene to be consistent with ec field named standard
 proteinStdGenes.genes = 'standard';
@@ -119,7 +127,7 @@ end
 
 model = addGenesRaven(model, proteinStdGenes);
 
-% Add a protein usage reaction
+% Add a protein usage reaction if not a light version
 if ~model.ec.geckoLight
     proteinStdUsageRxn.rxns            = {'usage_prot_standard'};
     proteinStdUsageRxn.rxnNames        = proteinStdUsageRxn.rxns;
@@ -153,7 +161,13 @@ for i = 1:numel(rxnsMissingGPR)
     kcatSubSystemIdx =  strcmpi(enzSubSystem_names, model.subSystems{rxnIdx});
 
     % Update .ec structure in model
-    model.ec.rxns(end+1)     = model.rxns(rxnIdx);
+    if ~model.ec.geckoLight
+        model.ec.rxns(end+1)     = model.rxns(rxnIdx);
+     % Add prefix in case is light version
+    else
+        model.ec.rxns{end+1}     = ['001_' model.rxns{rxnIdx}];
+    end
+
     if all(kcatSubSystemIdx)
         model.ec.kcat(end+1) = kcatSubSystem(kcatSubSystemIdx);
     else


### PR DESCRIPTION
### Main improvements in this PR:

Add standard kcats in light version models. 

**I hereby confirm that I have:**

- [ ] Tested my code with [all requirements](https://github.com/SysBioChalmers/GECKO) for running GECKO
- [ ] Selected `devel` as a target branch (top left drop-down menu)
