### PR TITLE
Fix: constraint flux exchange of a specific condition

### DIFF
--- a/src/geckomat/limit_proteins/constrainFluxData.m
+++ b/src/geckomat/limit_proteins/constrainFluxData.m
@@ -70,6 +70,9 @@ elseif ~isnumeric(condition)
     end
 end
 
+% Select the exchange fluxes of specified condition
+fluxData.exchFluxes = fluxData.exchFluxes(condition,:);
+
 %Set original c-source to zero
 model = setParam(model,'eq',params.c_source,0);
 %Set growth
@@ -82,7 +85,7 @@ switch maxMinGrowth
         model = setParam(model,'ub',params.bioRxn,1000);
 end
 
-negFlux = le(fluxData.exchFluxes,0); % less than or equal to 0
+negFlux = lt(fluxData.exchFluxes,0); % less than 0
 ub = fluxData.exchFluxes(~negFlux);
 posFlux = fluxData.exchRxnIDs(~negFlux);
 lb = fluxData.exchFluxes(negFlux);

--- a/src/geckomat/limit_proteins/flexibilizeProtConcs.m
+++ b/src/geckomat/limit_proteins/flexibilizeProtConcs.m
@@ -48,7 +48,7 @@ if nargin < 4 || isempty(iterPerEnzyme)
 end
 
 if nargin < 3 || isempty(foldChange)
-    foldChange = 0.5;
+    foldChange = 2;
 end
 
 if nargin < 2 || isempty(expGrowth)


### PR DESCRIPTION
### Main improvements in this PR:

When there are multiple conditions in proteomics integration, only one condition to `setParam` should be selected.

**I hereby confirm that I have:**

- [ ] Tested my code with [all requirements](https://github.com/SysBioChalmers/GECKO) for running GECKO
- [ ] Selected `devel` as a target branch (top left drop-down menu)
