### PR TITLE
fix: getECfromDatabase incorrect input definition

### DIFF
--- a/src/geckomat/get_enzyme_data/getECfromDatabase.m
+++ b/src/geckomat/get_enzyme_data/getECfromDatabase.m
@@ -28,7 +28,11 @@ function model = getECfromDatabase(model, ecRxns, action, modelAdapter)
 % Usage:
 %   model = getECfromDatabase(model, ecRxns, action, modelAdapter)
 
-if nargin < 2
+if nargin < 2 || isempty(ecRxns)
+    ecRnxs = true(numel(model.ec.rxns),1);
+end
+
+if nargin < 3 || isempty(action)
     action = 'display';
 end
 


### PR DESCRIPTION
### Main improvements in this PR:
- fix: `getECfromDatabase` incorrect definition of `ecRxns` and `action` input parameters

**I hereby confirm that I have:**

- [x] Tested my code with [all requirements](https://github.com/SysBioChalmers/GECKO) for running GECKO
- [x] Selected `devel` as a target branch (top left drop-down menu)
