### PR TITLE
fix: read runDLKcat output

### DIFF
--- a/protocol.m
+++ b/protocol.m
@@ -99,7 +99,7 @@ ecModel = findMetSmiles(ecModel);
 % DLKcat, while the output file is read back into MATLAB.
 writeDLKcatInput(ecModel);
 % runDLKcat will run the DLKcat algorithm via a Docker image
-%runDLKcat();
+runDLKcat();
 kcatList_DLKcat = readDLKcatOutput(ecModel);
 
 % STEP 8 Combine kcat from BRENDA and DLKcat
@@ -204,7 +204,7 @@ saveEcModel(ecModel,ModelAdapter,'yml','ecYeastGEMfull');
 
 %% STAGE 5: simulation and analysis
 % If starting from here, load some basic assets
-ecModel = loadEcModel('ecYeastGEMfull.yml',ModelAdapter);
+ecModel = loadEcModel('ecYeastGEMfull.yml');
 modelY = loadConventionalGEM();
 fluxData = loadFluxData;
 

--- a/src/geckomat/change_model/applyKcatConstraints.m
+++ b/src/geckomat/change_model/applyKcatConstraints.m
@@ -73,11 +73,11 @@ if ~model.ec.geckoLight
     end
     newKcats(kcatLast+1:end,:)=[];
     
-    sel = newKcats(:,4) ~= 0; %assign zero cost instead of inf when kcat == 0
+    sel = newKcats(:,4) > 0; %Only apply to non-zero kcat
     newKcats(sel,4) = newKcats(sel,4) * 3600; %per second -> per hour
     newKcats(sel,4) = newKcats(sel,5) ./ newKcats(sel,4); %MW/kcat
     newKcats(sel,4) = newKcats(sel,3) .* newKcats(sel,4); %Multicopy subunits.
-    newKcats(~sel,4) = 0;
+    newKcats(~sel,4) = 0; %Results in zero-cost
     
     %Replace rxns and enzymes with their location in model
     [~,newKcats(:,1)] = ismember(model.ec.rxns(newKcats(:,1)),model.rxns);

--- a/src/geckomat/gather_kcats/readDLKcatOutput.m
+++ b/src/geckomat/gather_kcats/readDLKcatOutput.m
@@ -45,7 +45,7 @@ fclose(fID);
 [rxns, genes, subs, kcats] = deal(DLKcatOutput{[1,2,3,6]});
 
 % Check if it contains any kcat values
-if all(cellfun(@isempty,kcats))
+if all(cellfun(@isempty,kcats)) || all(strcmpi(kcats,'NA'))
     error('DLKcat file does not contain any kcat values, please run runDLKcat() first.')
 end
 
@@ -53,13 +53,14 @@ end
 if ~all(ismember(subs,model.metNames))
     error('Not all substrates from DLKcat output can be found in model.metNames')
 end
+
 % Check that all reactions are in model.ec.rxns
 if ~all(ismember(rxns,model.ec.rxns))
     error('Not all reactions from DLKcat output can be found in model.ec.rxns')
 end
 
-% Filter out entries with no kcat value
-noOutput        = strcmp(kcats,'None');
+% Filter out entries with no numeric value
+noOutput        = cellfun(@isempty,regexpi(kcats,'[0-9]'));
 kcats           = str2double(kcats(~noOutput));
 rxns(noOutput)  = [];
 genes(noOutput) = [];

--- a/src/geckomat/gather_kcats/readDLKcatOutput.m
+++ b/src/geckomat/gather_kcats/readDLKcatOutput.m
@@ -51,12 +51,12 @@ end
 
 % Check that all substrates are in the model
 if ~all(ismember(subs,model.metNames))
-    error('Not all substrates from DLKcat output can be found in model.metNames')
+    error('Not all substrates from DLKcat output can be found in model.metNames. DLKcat was likely run with an input file that was generated from another ecModel.')
 end
 
 % Check that all reactions are in model.ec.rxns
 if ~all(ismember(rxns,model.ec.rxns))
-    error('Not all reactions from DLKcat output can be found in model.ec.rxns')
+    error('Not all reactions from DLKcat output can be found in model.ec.rxns. DLKcat was likely run with an input file that was generated from another ecModel.')
 end
 
 % Filter out entries with no numeric value


### PR DESCRIPTION
### Main improvements in this PR:
- fix:
  - check whether `runDLKcat` was run on `DLKcat.tsv` (solves #278)
  - filter out any non-numeric kcat value in `DLKcat.tsv`
 
**I hereby confirm that I have:**
<!-- Note: replace [ ] with [X] to check the box -->
- [x] Selected `develop` as a target branch (top left drop-down menu)
