### PR TITLE
fix: if organism is in KEGG multiple times

### DIFF
--- a/src/geckomat/gather_kcats/fuzzyKcatMatching.m
+++ b/src/geckomat/gather_kcats/fuzzyKcatMatching.m
@@ -497,7 +497,9 @@ end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 function org_index = find_inKEGG(org_name,names)
 org_index      = find(strcmpi(org_name,names));
-if isempty(org_index)
+if numel(org_index)>1
+    org_index = org_index(1);
+elseif isempty(org_index)
     i=1;
     while isempty(org_index) && i<length(names)
         str = names{i};


### PR DESCRIPTION
### Main improvements in this PR:
- fix:
  - `fuzzyKcatMatching` solves #277 when KEGG has multiple entries with the same organism name.  

**I hereby confirm that I have:**
<!-- Note: replace [ ] with [X] to check the box -->
- [x] Selected `develop` as a target branch (top left drop-down menu)
