### PR TITLE
fix: error if any match in customKcats

### DIFF
--- a/src/geckomat/change_model/applyCustomKcats.m
+++ b/src/geckomat/change_model/applyCustomKcats.m
@@ -165,7 +165,11 @@ if ~model.ec.geckoLight
     end
 
     % Apply the new kcat values to the model
-    model = applyKcatConstraints(model, rxnToUpdate);
+    if ~isempty(find(rxnToUpdate, 1))
+        model = applyKcatConstraints(model, rxnToUpdate);
+    else
+        disp('No matches found. Consider checking the IDs or proteins in customKcats.')
+    end
 
     rxnUpdated = model.ec.rxns(find(rxnToUpdate));
 

--- a/src/geckomat/change_model/applyKcatConstraints.m
+++ b/src/geckomat/change_model/applyKcatConstraints.m
@@ -36,7 +36,11 @@ elseif iscellstr(updateRxns) || ischar(updateRxns) || isstring(updateRxns)
     updateRxnsIds = convertCharArray(updateRxns);
     updateRxns = ismember(rxns,updateRxnsIds);
 end
-    
+ 
+if isempty(find(updateRxns, 1)) || isempty(updateRxns)
+     errro('No reaction to update or updateRxns is logical but without any true value')
+end
+
 if ~isfield(model,'ec')
     error(['No model.ec structure could be found: the provided model is'...
            ' not a valid GECKO3 ecModel. First run makeEcModel(model).'])


### PR DESCRIPTION
### Main improvements in this PR:

Fix bug where if any reaction does not match with data in customKcats cause and error. Reported in #291  

**I hereby confirm that I have:**
<!-- Note: replace [ ] with [X] to check the box -->
- [x] Selected `develop` as a target branch (top left drop-down menu)
