### PR TITLE
Feat: ignore in tunning kcats user defined proteins

### DIFF
--- a/src/geckomat/kcat_sensitivity_analysis/sensitivityTuning.m
+++ b/src/geckomat/kcat_sensitivity_analysis/sensitivityTuning.m
@@ -1,4 +1,4 @@
-function [model, tunedKcats] = sensitivityTuning(model, desiredGrowthRate, modelAdapter, foldChange, verbose)
+function [model, tunedKcats] = sensitivityTuning(model, desiredGrowthRate, modelAdapter, foldChange, protToIgnore, verbose)
 % sensitivityTuning
 %    Function that relaxes the most limiting kcats until a certain growth rate
 %    is reached. The function will update kcats in model.ec.kcat.
@@ -10,6 +10,8 @@ function [model, tunedKcats] = sensitivityTuning(model, desiredGrowthRate, model
 %                      default model adapter).
 %   foldChange         kcat values will be increased by this fold-change.
 %                      (Opt, default 10)
+%   protToIgnore       vector of protein ids to be ignore in tuned kcats.
+%                      e.g. {'P38122', 'Q99271'} (Optional, default = [])
 %   verbose            logical whether progress should be reported (Optional,
 %                      default true)
 %
@@ -26,10 +28,13 @@ function [model, tunedKcats] = sensitivityTuning(model, desiredGrowthRate, model
 %                      newKcat  kcat values in the output model, after tuning
 %
 % Usage:
-%   [model, tunedKcats] = sensitivityTuning(model, desiredGrowthRate, modelAdapter, foldChange, verbose)
+%   [model, tunedKcats] = sensitivityTuning(model, desiredGrowthRate, modelAdapter, foldChange, protToIgnore, verbose)
 
-if nargin < 5 || isempty(verbose)
+if nargin < 6 || isempty(verbose)
     verbose = true;
+end
+if nargin < 5 || isempty(protToIgnore)
+    protToIgnore = {};
 end
 if nargin < 4 || isempty(foldChange)
     foldChange = 10;
@@ -57,6 +62,7 @@ lastGrowth = 0;
 if ~m.ec.geckoLight
     %for the full model, we first find the draw reaction with the most flux
     drawRxns = startsWith(m.rxns, 'usage_prot_');
+    idxToIgnore = cellfun(@(x) find(strcmpi(model.rxns, ['usage_prot_' x])), protToIgnore);
     iteration = 1;
     while true
         [res,hs] = solveLP(m,0,[],hs); %skip parsimonius, only takes time
@@ -76,6 +82,8 @@ if ~m.ec.geckoLight
         %find the highest draw_prot rxn flux
         drawFluxes           = zeros(length(drawRxns),1);
         drawFluxes(drawRxns) = res.x(drawRxns);
+        % Remove from the list user defined proteins
+        drawFluxes(idxToIgnore) = 0;
         [~,sel]              = min(drawFluxes); % since bounds -1000 to 0
         %Now get the metabolite
         metSel               = m.S(:,sel) < 0; % negative coeff
@@ -91,6 +99,12 @@ if ~m.ec.geckoLight
 
 else
     origRxns = extractAfter(m.ec.rxns,4);
+    %find the reactions involved in proteins to be ignored
+    idxToIgnore = cellfun(@(x) find(m.ec.rxnEnzMat(:, strcmpi(m.ec.enzymes, x))), protToIgnore, 'UniformOutput', false);
+    %create an unique vector
+    idxToIgnore = unique(cat(1, idxToIgnore{:}));
+    %get the correct idx in model.rxns
+    idxToIgnore = cellfun(@(x) find(strcmpi(m.rxns, x)), origRxns(idxToIgnore));
     iteration = 1;
     while true
         res = solveLP(m,0); %skip parsimonius, only takes time
@@ -109,6 +123,7 @@ else
         iteration       = iteration + 1;
         %find the highest protein usage flux
         protPoolStoich  = m.S(strcmp(m.mets, 'prot_pool'),:).';
+        protPoolStoich(idxToIgnore) = 0;
         [~,sel]         = min(res.x .* protPoolStoich); %max consumption
         kcatList        = [kcatList, sel];
         rxn             = m.rxns(sel.');


### PR DESCRIPTION
### Main improvements in this PR:

- User can define a list of protein which will not be considered in `sensitivityTuning`. 
- Solves #294 
- Tested with both full and light ecModels in yeast following the `protocol.m`

**I hereby confirm that I have:**
<!-- Note: replace [ ] with [X] to check the box -->
- [x] Selected `develop` as a target branch (top left drop-down menu)
