### PR TITLE
feat: a function that creates a the project structure an adapter class

### DIFF
--- a/src/geckomat/model_adapter/adapterTemplate.m
+++ b/src/geckomat/model_adapter/adapterTemplate.m
@@ -1,0 +1,80 @@
+classdef KEY_CLASSNAME < ModelAdapter
+    methods
+        function obj = KEY_CLASSNAME()
+            % Set initial values of the obj.params - they can be changed by the user
+            
+            % Directory where all model-specific files and scripts are kept.
+            % Is assumed to follow the GECKO-defined folder structure. The
+            % code below refers to userData/yourModel in the GECKO path.
+            obj.params.path = fullfile('KEY_PATH', 'KEY_NAME');
+
+			% Path to the conventional GEM that this ecModel will be based on.
+			obj.params.convGEM = fullfile(obj.params.path,'models','yourModel.xml');
+
+			% Average enzyme saturation factor
+			obj.params.sigma = 0.5;
+
+			% Total protein content in the cell [g protein/gDw]
+			obj.params.Ptot = 0.5;
+
+			% Fraction of enzymes in the model [g enzyme/g protein]
+			obj.params.f = 0.5;
+            
+            % Growth rate the model should be able to reach when not
+            % constraint by nutrient uptake (e.g. max growth rate) [1/h]
+			obj.params.gR_exp = 0.41;
+
+			% Provide your organism scientific name
+			obj.params.org_name = 'saccharomyces cerevisiae';
+            
+            % Matching name for Complex Portal
+            obj.params.complex_org_name = 'Saccharomyces cerevisiae';
+
+			% Provide your organism KEGG ID, selected at
+			% https://www.genome.jp/kegg/catalog/org_list.html
+			obj.params.keggID = 'sce';
+            % Field for KEGG gene identifier; should match the gene
+            % identifiers used in the model. With 'kegg', it takes the
+            % default KEGG Entry identifier (for example YER023W here:
+            % https://www.genome.jp/dbget-bin/www_bget?sce:YER023W).
+            % Alternatively, gene identifiers from the "Other DBs" section
+            % of the KEGG page can be selected. For example "NCBI-GeneID",
+            % "UniProt", or "Ensembl". Not all DB entries are available for
+            % all organisms and/or genes.
+            obj.params.keggGeneIdentifier = 'kegg';
+
+			% Provide what identifier should be used to query UniProt.
+            % Select proteome IDs at https://www.uniprot.org/proteomes/
+            % or taxonomy IDs at https://www.uniprot.org/taxonomy.
+            obj.params.uniprotIDtype = 'taxonomy_id'; % 'proteome' or 'taxonomy_id'
+			obj.params.uniprotID = '559292'; % should match the ID type
+            % Field for Uniprot gene ID - should match the gene ids used in the 
+            % model. It should be one of the "Returned Field" entries under
+            % "Names & Taxonomy" at this page: https://www.uniprot.org/help/return_fields
+            obj.params.uniprotGeneIdField = 'gene_oln';
+            % Whether only reviewed data from UniProt should be considered.
+            % Reviewed data has highest confidence, but coverage might be (very)
+            % low for non-model organisms
+            obj.params.uniprotReviewed = true;
+
+			% Reaction ID for glucose exchange reaction (or other preferred carbon source)
+			obj.params.c_source = 'r_1714'; 
+
+			% Reaction ID for biomass pseudoreaction
+			obj.params.bioRxn = 'r_4041';
+
+			% Reaction ID for non-growth associated maitenance pseudoreaction
+			obj.params.NGAM = 'r_4046';
+
+			% Compartment name in which the added enzymes should be located
+			obj.params.enzyme_comp = 'cytoplasm';
+        end
+		
+		function [spont,spontRxnNames] = getSpontaneousReactions(obj,model)
+            % Indicates how spontaneous reactions are identified. Here it
+            % is done by the reaction have 'spontaneous' in its name.
+			spont = contains(model.rxnNames,'spontaneous');
+			spontRxnNames = model.rxnNames(spont);
+		end
+	end
+end

--- a/src/geckomat/utilities/startGECKOproject.m
+++ b/src/geckomat/utilities/startGECKOproject.m
@@ -1,0 +1,59 @@
+function startGECKOproject(name, path)
+% startGECKOproject
+%   Function that create a basic project structure for GECKO. If a project
+%   with the same name exits, the project will not be created
+%
+% Input:
+%   name               an name for the folder struture used in GECKO. Also
+%                      creates a basic adapter class, which must be manually
+%                      adjusted. If not defined, a dialog box will appear.
+%   path               a path where to create the folder. If not defined, a
+%                      dialog box will appear.
+%
+% Usage:
+%   startGECKOproject(name, path)
+
+if nargin < 1 || isempty(name)
+    prompt = {'Please provide a project name (e.g. ecYeastGEM)'};
+    dlgtitle = 'Project name';
+    dims = [1 100];
+    definput = {'ecModelGEM'};
+    opts.Interpreter = 'tex';
+    name = inputdlg(prompt,dlgtitle,dims,definput,opts);
+    name = char(name);
+end
+
+if nargin < 2 || isempty(path)
+    path = uigetdir('Project Folder path');
+end
+
+fullPath = fullfile(path, name);
+% Validate if the project does not exits
+if ~exist(fullPath, 'dir')
+    % Create the subfolder
+    dir = {'code', 'data', 'models', 'output'};
+    for i = 1:length(dir)
+        status = mkdir(fullPath, dir{i});
+    end
+
+    % Read the template adapter class
+    fid = fopen(fullfile(findGECKOroot, 'src', 'geckomat', ...
+        'model_adapter', 'adapterTemplate.m'));
+    f = fread(fid, '*char')';
+    fclose(fid);
+
+    % Replace key values
+    f = strrep(f, 'KEY_CLASSNAME', [name 'Adapter']);
+    f = strrep(f, 'KEY_PATH', path);
+    f = strrep(f, 'KEY_NAME', name);
+
+    % Save the class file
+    filename = fullfile(path, name, [name 'Adapter.m']);
+    fid = fopen(filename, 'w');
+    fwrite(fid, f);
+    fclose(fid);
+else
+    warning('A project with the same name exits at the same location. The project was not created')
+end
+
+end

--- a/src/geckomat/utilities/startGECKOproject.m
+++ b/src/geckomat/utilities/startGECKOproject.m
@@ -34,6 +34,8 @@ if ~exist(fullPath, 'dir')
     dir = {'code', 'data', 'models', 'output'};
     for i = 1:length(dir)
         status = mkdir(fullPath, dir{i});
+        fid = fopen(fullfile(fullPath, dir{i}, '.keep'), 'w');
+        fclose(fid);
     end
 
     % Read the template adapter class


### PR DESCRIPTION
### Main improvements in this PR:

- Propose a function that create the basic GECKO 3 project structure. Instead of copy and paste `yourModel` folder, user can use `startGECKOproject()` that creates a new folder with the `{code, data, models, output}` structure required. Moreover it write a basic adapter class that can be more user friendly to adjust. 
- For now, this is a proposal, in case is accepted, `yourModel` folder will be removed and protocol needs update. 
- This branch was created using develop as base branch

**I hereby confirm that I have:**
<!-- Note: replace [ ] with [X] to check the box -->
- [ ] Selected `develop` as a target branch (top left drop-down menu)
