### PR TITLE
fix: getStandardKcat and applyKcatConstraints

### DIFF
--- a/src/geckomat/change_model/applyKcatConstraints.m
+++ b/src/geckomat/change_model/applyKcatConstraints.m
@@ -104,6 +104,8 @@ else %GECKO light formulation, where prot_pool represents all usages
         % summed per reaction), and divide by their kcat, to get a vector
         % of MW/kcat values.
         MWkcat = (model.ec.rxnEnzMat(ecIdx,:) * model.ec.mw) ./ model.ec.kcat(ecIdx);
+        % If kcat was zero, MWkcat is Inf. Correct back to zero
+        MWkcat(abs(MWkcat)==Inf)=0;
         % Select the lowest MW/kcat (= most efficient), and convert to /hour
         model.S(prot_pool_idx, hasEc(i)) = -min(MWkcat/3600);
     end

--- a/src/geckomat/change_model/applyKcatConstraints.m
+++ b/src/geckomat/change_model/applyKcatConstraints.m
@@ -90,43 +90,22 @@ if ~model.ec.geckoLight
     model.S(linearIndices) = -newKcats(:,4); %Substrate = negative
     
 else %GECKO light formulation, where prot_pool represents all usages
-    nextIndex = 1;
     prot_pool_idx = find(ismember(model.mets,'prot_pool'));
     %first remove the prefix of all rxns
-    modRxns = extractAfter(model.ec.rxns,4);
-    for i = 1:numel(model.rxns)
-        if nextIndex <= length(model.ec.rxns) && strcmp(model.rxns(i), modRxns(nextIndex))
-            updated = false;
-            newMWKcats=[];
-            %Reactions with isozymes will have several rows in ec.rxns etc.
-            %Loop through all reactions, and for each reaction look at all isozymes
-            %Then use the lowest MW/kcat among the isozymes - when optimizing, that
-            %is the one that will be used anyway.
-            while true
-                if updateRxns(i)
-                    updated = true;
-                end
-                enzymes = find(model.ec.rxnEnzMat(nextIndex,:));
-                if model.ec.kcat(nextIndex) == 0
-                    %newMWKcats = [newMWKcats 0]; - if some are missing, just ignore those
-                else
-                    MW = sum(model.ec.mw(enzymes) .* model.ec.rxnEnzMat(nextIndex,enzymes).'); %multiply MW with number of subunits
-                    newMWKcats = [newMWKcats MW/model.ec.kcat(nextIndex)]; %Light model: protein usage is MW/kcat
-                end                
-                nextIndex = nextIndex + 1;
-                if  nextIndex > length(model.ec.rxns) || ~strcmp(model.rxns(i), modRxns(nextIndex))
-                    break;
-                end
-            end
-            if (updated)
-                if isempty(newMWKcats)
-                    newMWKcats = 0; %no cost
-                end
-                %Light model: always use the "cheapest" isozyme, that is what the 
-                %optimization will choose anyway unless isozymes are individually constrained.
-                model.S(prot_pool_idx, i) = -min(newMWKcats)/3600; % 3600: per second -> per hour
-            end
-        end
+    modRxns     = extractAfter(model.ec.rxns,4);
+    % Map ec-reactions to model.rxns
+    [hasEc,~]   = ismember(model.rxns,modRxns);
+    [~,rxnIdx]  = ismember(modRxns,model.rxns);
+    hasEc = find(hasEc & updateRxns);
+    for i = 1:numel(hasEc)
+        % Get all isoenzymes per reaction
+        ecIdx = find(rxnIdx == hasEc(i));
+        % Multiply enzymes with their MW (they are then automatically
+        % summed per reaction), and divide by their kcat, to get a vector
+        % of MW/kcat values.
+        MWkcat = (model.ec.rxnEnzMat(ecIdx,:) * model.ec.mw) ./ model.ec.kcat(ecIdx);
+        % Select the lowest MW/kcat (= most efficient), and convert to /hour
+        model.S(prot_pool_idx, hasEc(i)) = -min(MWkcat/3600);
     end
 end
 end

--- a/src/geckomat/gather_kcats/getStandardKcat.m
+++ b/src/geckomat/gather_kcats/getStandardKcat.m
@@ -189,23 +189,21 @@ if ~any(strcmp(model.mets,'prot_standard'))
         proteinStdUsageRxn.grRules      = proteinStdGenes.genes;
 
         model = addRxns(model, proteinStdUsageRxn);
-
-        % Update .ec structure in model
-        model.ec.genes(end+1)      = {'standard'};
-        model.ec.enzymes(end+1)    = {'standard'};
-        model.ec.mw(end+1)         = standardMW;
-        model.ec.sequence(end+1)   = {''};
-        % Additional info
-        if isfield(model.ec,'concs')
-            model.ec.concs(end+1)  = nan();
-        end
-
-        % Expand the enzyme rxns matrix
-        model.ec.rxnEnzMat =  [model.ec.rxnEnzMat, zeros(length(model.ec.rxns), 1)]; % 1 new enzyme
-        model.ec.rxnEnzMat =  [model.ec.rxnEnzMat; zeros(length(rxnsMissingGPR), length(model.ec.enzymes))]; % new rxns
     end
-end
+    % Update .ec structure in model
+    model.ec.genes(end+1)      = {'standard'};
+    model.ec.enzymes(end+1)    = {'standard'};
+    model.ec.mw(end+1)         = standardMW;
+    model.ec.sequence(end+1)   = {''};
+    % Additional info
+    if isfield(model.ec,'concs')
+        model.ec.concs(end+1)  = nan();
+    end
 
+    % Expand the enzyme rxns matrix
+    model.ec.rxnEnzMat =  [model.ec.rxnEnzMat, zeros(length(model.ec.rxns), 1)]; % 1 new enzyme
+    model.ec.rxnEnzMat =  [model.ec.rxnEnzMat; zeros(length(rxnsMissingGPR), length(model.ec.enzymes))]; % new rxns
+end
 numRxns = length(model.ec.rxns);
 stdMetIdx = find(strcmpi(model.ec.enzymes, 'standard'));
 

--- a/src/geckomat/gather_kcats/getStandardKcat.m
+++ b/src/geckomat/gather_kcats/getStandardKcat.m
@@ -90,42 +90,30 @@ standardKcat = median(model.ec.kcat(rxnsKcatZero), 'omitnan');
 
 % If the model have subSystems assigned calculate kcat based on subSystem
 if isfield(model,'subSystems') && ~all(cellfun(@isempty, model.subSystems))
-
     standard = false;
-    enzSubSystems = cell(numel(model.ec.rxns), 1);
-
-    % Get the subSystem for the rxns with a GPR
-    for i = 1:numel(model.ec.rxns)
-        if ~model.ec.geckoLight
-            idx = strcmpi(model.rxns, model.ec.rxns{i});
-        else
-            % Remove prefix
-            rxnId = model.ec.rxns{i}(5:end);
-            idx = strcmpi(model.rxns, rxnId);
-        end
-        % In case there is more than one subSystem select the first one
-        if length(model.subSystems{idx}) > 1
-            enzSubSystems(i,1) = model.subSystems{idx}(1);
-        else
-            enzSubSystems(i,1) = model.subSystems{idx};
-        end
+    if model.ec.geckoLight
+        modRxns = extractAfter(model.ec.rxns,4);
+    else
+        modRxns = model.ec.rxns;
     end
-
-    % if reactions in model.ec.rxns have a susbSystem assigned, else assign
-    % standard value
+    % Map ec-rxns to model.rxns
+    [~,rxnIdx]  = ismember(modRxns,model.rxns);
+    % Choose first subSystem
+    enzSubSystems = flattenCell(model.subSystems(rxnIdx));
+    enzSubSystems = enzSubSystems(:,1);
     if ~all(cellfun(@isempty, enzSubSystems))
-        % Determine the subSystems in model.ec
-        [enzSubSystem_group, enzSubSystem_names] = findgroups(enzSubSystems(rxnsKcatZero));
 
-        % Calculate the mean kcat value for each subSystem in model.ec
-        kcatSubSystem = splitapply(@mean, model.ec.kcat(rxnsKcatZero), enzSubSystem_group);
-
-        % Calculate the number of reactions for each subSystem in model.ec
-        numRxnsSubSystem = splitapply(@numel, model.ec.rxns(rxnsKcatZero), enzSubSystem_group);
-
-        % Find subSystems which contains < threshold rxns and assign a standard value
-        lowerThanTresh = numRxnsSubSystem < threshold;
-        kcatSubSystem(lowerThanTresh) = standardKcat;
+    % Make list of unique subsystems, and which rxns are linked to them
+    [enzSubSystem_names, ~, rxnToSub] = unique(enzSubSystems);
+    % Make matrix of ec-rxns vs. unique subsystem index
+    ind = sub2ind([numel(enzSubSystem_names) numel(enzSubSystems)],rxnToSub',1:numel(rxnToSub));
+    kcatSubSystem = false([numel(enzSubSystem_names) numel(enzSubSystems)]);
+    kcatSubSystem(ind) = true;
+    % Number of kcats per subSystem
+    kcatsPerSubSystem = sum(kcatSubSystem,2);
+    % Calculate average kcat values per subSystem
+    kcatSubSystem = (kcatSubSystem*model.ec.kcat)./kcatsPerSubSystem;
+    kcatSubSystem(kcatsPerSubSystem < threshold) = standardKcat;
     else
         standard = true;
         disp('No subSystem-specific kcat values can be calculated')
@@ -257,5 +245,42 @@ if fillZeroKcat
     rxnsNoKcat = model.ec.rxns(zeroKcat);
 else
     rxnsNoKcat = [];
+end
+end
+
+function Cflat = flattenCell(C,strFlag)
+%FLATTENCELL  Flatten a nested column cell array into a matrix cell array.
+%
+% CFLAT = FLATTENCELL(C) takes a column cell array in which one or more
+% entries is a nested cell array, and flattens it into a 2D matrix cell
+% array, where the nested entries are spread across new columns.
+%
+% CFLAT = FLATTENCELL(C,STRFLAG) if STRFLAG is TRUE, empty entries in the
+% resulting CFLAT will be replaced with empty strings {''}. Default = FALSE
+if nargin < 2
+    strFlag = false;
+end
+
+% determine which entries are cells
+cells = cellfun(@iscell,C);
+
+% determine number of elements in each nested cell
+cellsizes = cellfun(@numel,C);
+cellsizes(~cells) = 1;  % ignore non-cell entries
+
+% flatten single-entry cells
+Cflat = C;
+Cflat(cells & (cellsizes == 1)) = cellfun(@(x) x{1},Cflat(cells & (cellsizes == 1)),'UniformOutput',false);
+
+% iterate through multi-entry cells
+multiCells = find(cellsizes > 1);
+for i = 1:length(multiCells)
+    cellContents = Cflat{multiCells(i)};
+    Cflat(multiCells(i),1:length(cellContents)) = cellContents;
+end
+
+% change empty elements to strings, if specified
+if ( strFlag )
+    Cflat(cellfun(@isempty,Cflat)) = {''};
 end
 end

--- a/src/geckomat/get_enzyme_data/copyECtoGEM.m
+++ b/src/geckomat/get_enzyme_data/copyECtoGEM.m
@@ -1,0 +1,37 @@
+function ecModel = copyECtoGEM(ecModel, overwrite)
+% copyECtoGEM
+%   Copies EC numbers from ecModel.ec.eccodes to ecModel.eccodes.
+%
+% Input:
+%   ecModel     an ecModel in GECKO 3 format (with ecModel.ec structure)
+%   overwrite   logical that specifies if existing (non-empty) 
+%               ecModel.eccodes entries should be overwritten. Empty
+%               ecModel.eccodes entries are always overwritten if possible.
+%               default false.
+%
+% Output:
+%   ecModel     ecModel with populated model.eccodes
+%
+% Usage:
+%   ecModel = getECfromGEM(ecModel, overwrite)
+
+if nargin < 2 || isempty(overwrite)
+    overwrite = false;
+end
+if ~isfield(ecModel.ec,'eccodes')
+    error('ecModel.ec.eccodes does not exist')
+end
+
+[a,b] = ismember(ecModel.rxns,ecModel.ec.rxns);
+if ~isfield(ecModel,'eccodes')
+    ecModel.eccodes = cell(numel(ecModel.rxns),1);
+end
+
+if overwrite
+    ecModel.eccodes(a) = ecModel.ec.eccodes(b(a));
+else % Only replace emptyEcCodes
+    emptyEcCodes = cellfun(@isempty, ecModel.eccodes);
+    a = a & emptyEcCodes;
+    ecModel.eccodes(a) = ecModel.ec.eccodes(b(a));
+end
+end


### PR DESCRIPTION
### Main improvements in this PR:
- fix:
  - `getStandardKcat` failed to add constraints after `applyKcatConstraints` due to missing `rxnEnzMat` entries
- refactor:
  - `applyKcatConstraints` faster on light ecModels by avoiding for-loops
  - `getStandardKcat` faster by avoiding for-loops and findgroups
- feat:
  - `copyECtoGEM` function to copy `ecModel.ec.eccodes` to `ecModel.eccodes` (reviewer request)

**I hereby confirm that I have:**
<!-- Note: replace [ ] with [X] to check the box -->
- [x] Selected `develop` as a target branch (top left drop-down menu)
