### PR TITLE
doc: clarify PR merge strategies in contrib guide

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -145,6 +145,7 @@ The following points should be considered when merging branches to `develop`:
 
 * Make sure the branch gets accepted by at least one developer with writing access.
 * Wait at least a day before merging, to allow other developers to inspect the pull request.
+* To simplify the git history, use "Squash and merge" in pull requests to `develop` (but **never** use this option when merging to `main`, see also below).
 * As soon as the branch is merged, confirm that `develop` is still possible to merge to `main` (this can be checked [here](https://github.com/SysBioChalmers/GECKO/compare/develop)). If conflicts appear, fix the conflict _locally_ as soon as possible in `develop` and then push it (note, **DO NOT** pull any other changes from `main` to `develop`, just the single file that is creating the conflict).
 
 ### Releasing a new version
@@ -169,8 +170,9 @@ When releasing, please follow these steps:
    - Specify the intended version in the title, e.g. `GECKO 3.0.1`
    - Indicating all new features/fixes/etc. and referencing every previous pull request included (examples [here](https://github.com/SysBioChalmers/GECKO/releases)).
    - If any [issue](https://github.com/SysBioChalmers/GECKO/issues) gets solved in the release, write in the pull request description "Closes #X", where "X" is the issue number. That way the issue will be automatically closed after merge.
-2. Wait at least a day for at least one  approval. The GitHub Actions must also pass successfully.
-3. Merge the pull request from `develop` to `main`.
-4. Make the [new release](https://github.com/SysBioChalmers/GECKO/releases/new) at GitHub:
+2. Wait at least a day for at least one approval. The GitHub Actions must also pass successfully.
+3. Merge the pull request from `develop` to `main` with the option "Create a merge commit", **not** "Squash and merge".
+4. Edit the `version.txt` in the `main` branch directly [link](https://github.com/SysBioChalmers/GECKO/edit/main/version.txt) to refer to the new version number. Commit the change directly to the `main` branch.
+5. Make the [new release](https://github.com/SysBioChalmers/GECKO/releases/new) at GitHub:
    - Define a new tag with the version, prefixed by `v`: e.g. `v3.0.1`.
    - Copy the description from the corresponding PR from step 1.

--- a/.github/ISSUE_TEMPLATE/bug-detected.md
+++ b/.github/ISSUE_TEMPLATE/bug-detected.md
@@ -1,6 +1,6 @@
 ---
 name: Bug detected
-about: GECKO is not working as it should...
+about: Report a bug if GECKO was functioning as it should.
 title: Bug detected
 labels: bug
 assignees: ''
@@ -13,18 +13,22 @@ assignees: ''
 - What have you tried yourself to fix it? -->
 
 #### Reproducing these results:
-<!-- If applicable, please attach the problematic code. -->
+<!-- If applicable, please attach the problematic code. This
+is very useful for us to replicate the problem you encountered. -->
 ```matlab
 % If you worked on matlab, paste your code here
 ```
 
 #### System information
 <!-- Please report details of the system where you encountered the bug. -->
-* Operating system: <!-- (Windows/Mac/Linux; include version) -->
+* Operating system: <!-- Windows/Mac/Linux; include version -->
 * MATLAB version: <!-- E.g. 2022b -->
-* GECKO version: <!-- If you did not use the latest GECKO version, have you tried to update and encountered the same problem? -->
+* GECKO version: <!-- Have you tried the latest GECKO version? -->
+* RAVEN version: <!-- Output from checkInstallation -->
+* Solver: <!-- Gurobi (include version) / glpk / cobra / etc. --> 
 
-**I hereby confirm that I have:**
-- [ ] Tested my code with [all requirements](https://github.com/SysBioChalmers/GECKO) for running GECKO
-- [ ] Done this analysis in the `main` branch of the repository
-- [ ] Checked that a similar issue does not exist already
+#### I hereby confirm that:
+<!-- Replace [ ] with [X] to check the box:-->
+- [ ] My GECKO installation met [all requirements](https://github.com/SysBioChalmers/GECKO#required-software).
+- [ ] This bug occurs in the `main` branch of the repository.
+- [ ] A similar [issue](https://github.com/SysBioChalmers/GECKO/issues) does not already exist.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,4 +2,4 @@ blank_issues_enabled: true
 contact_links:
   - name: Gitter Channel
     url: https://gitter.im/SysBioChalmers/GECKO
-    about: Please ask and answer questions here.
+    about: You may also ask questions (or contribute with answers) at the GECKO Gitter channel.

--- a/.github/ISSUE_TEMPLATE/new-feature.md
+++ b/.github/ISSUE_TEMPLATE/new-feature.md
@@ -1,10 +1,9 @@
 ---
 name: New feature
-about: You would like GECKO to do something it does not yet do.
+about: You can propose a new or modified features if you would like GECKO to do something it is not yet able to do.
 title: New feature
 labels: enhancement
 assignees: ''
-
 ---
 
 ### Description of the new feature:
@@ -14,6 +13,7 @@ assignees: ''
 - Do you have an idea on how to implement this feature?
 - Will you implement this feature yourself (in that case, you can Assign yourself in the top right corner) or need help with this? We will gladly support you in this! -->
 
-**I hereby confirm that I have:**
-- [ ] Done this analysis in the `main` branch of the repository
-- [ ] Checked that a similar issue does not exist already
+#### I hereby confirm that:
+<!-- Replace [ ] with [X] to check the box:-->
+- [ ] The new feature is not already in the `main` branch of the repository.
+- [ ] A similar [issue](https://github.com/SysBioChalmers/GECKO/issues) does not already exist.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,9 +1,14 @@
 ### Main improvements in this PR:
 <!-- Pointwise mention what changes were made in what function. Examples: 
-- fix bug where `functionName` failed to do function X
-- updated all documentation 
-- resolves issue #12345 -->
+- Fixes:
+  - `functionName` failed to do function X
+- Documentation:
+  - updated all documentation 
+- Features:
+  - Introduced option to do function Y (issue #12345) -->
 
-**I hereby confirm that I have:**
-<!-- Note: replace [ ] with [X] to check the box -->
-- [ ] Selected `develop` as a target branch (top left drop-down menu)
+#### Instructions on merging this PR:
+<!-- Chose ONE of the following two options
+and replace [ ] with [X] to check the box.-->
+- [ ] This PR has `develop` as target branch, and will be resolved with a *squash-merge*.
+- [ ] This PR has `main` as target branch, and will be resolved with a *merge commit*.


### PR DESCRIPTION
### Main improvements in this PR:
- Documentation:
  - Clarify PR merging strategies to `develop` (squash-merge) and `main` (merge commit) in _Contributor guidelines_.
  - Change PR template to nudge towards using the correct PR merging strategy.
  - Instruct in _Contributor guidelines_ to increment `version.txt` with each release.


**I hereby confirm that I have:**
<!-- Note: replace [ ] with [X] to check the box -->
- [x] Selected `develop` as a target branch (top left drop-down menu)
