### PR TITLE
fix: calculateFfactor if paxDB has taxID !4 digits

### DIFF
--- a/doc/src/geckomat/limit_proteins/calculateFfactor.html
+++ b/doc/src/geckomat/limit_proteins/calculateFfactor.html
@@ -114,7 +114,7 @@ This function is called by:
 0054     fileContent = textscan(fID,<span class="string">'%s %s %f'</span>,<span class="string">'delimiter'</span>,<span class="string">'\t'</span>,<span class="string">'HeaderLines'</span>,headerLines);
 0055     genes       = fileContent{2};
 0056     <span class="comment">%Remove internal geneIDs modifiers</span>
-0057     genes       = regexprep(genes,<span class="string">'(\d{4}).'</span>,<span class="string">''</span>);
+0057     genes       = regexprep(genes,<span class="string">'^\d+\.'</span>,<span class="string">''</span>);
 0058     level       = fileContent{3};
 0059     fclose(fID);
 0060     [a,b]       = ismember(genes,uniprotDB.genes);

--- a/src/geckomat/limit_proteins/calculateFfactor.m
+++ b/src/geckomat/limit_proteins/calculateFfactor.m
@@ -54,7 +54,7 @@ if ischar(protData) && endsWith(protData,'paxDB.tsv')
     fileContent = textscan(fID,'%s %s %f','delimiter','\t','HeaderLines',headerLines);
     genes       = fileContent{2};
     %Remove internal geneIDs modifiers
-    genes       = regexprep(genes,'(\d{4}).','');
+    genes       = regexprep(genes,'^\d+\.','');
     level       = fileContent{3};
     fclose(fID);
     [a,b]       = ismember(genes,uniprotDB.genes);


### PR DESCRIPTION
### Main improvements in this PR:
- Fixes:
  - 'calculateFfactor` handle data from PAXdb if the taxonomic ID is not 4 digits long (solves #345)

#### Instructions on merging this PR:
<!-- Chose ONE of the following two options
and replace [ ] with [X] to check the box.-->
- [X] This PR has `develop` as target branch, and will be resolved with a *squash-merge*.
- [ ] This PR has `main` as target branch, and will be resolved with a *merge commit*.
