### PR TITLE
fix: runDLKcat if path has spaces

### DIFF
--- a/doc/src/geckomat/gather_kcats/runDLKcat.html
+++ b/doc/src/geckomat/gather_kcats/runDLKcat.html
@@ -90,7 +90,7 @@ This function is called by:
 0035 <span class="keyword">end</span>
 0036 
 0037 disp(<span class="string">'Running DLKcat prediction, this may take many minutes, especially the first time.'</span>)
-0038 status = system([<span class="string">'docker run --rm -v '</span> fullfile(params.path,<span class="string">'/data'</span>) <span class="string">':/data ghcr.io/sysbiochalmers/dlkcat-gecko:0.1 /bin/bash -c &quot;python DLKcat.py /data/DLKcat.tsv /data/DLKcatOutput.tsv&quot;'</span>]);
+0038 status = system([<span class="string">'docker run --rm -v &quot;'</span> fullfile(params.path,<span class="string">'/data'</span>) <span class="string">'&quot;:/data ghcr.io/sysbiochalmers/dlkcat-gecko:0.1 /bin/bash -c &quot;python DLKcat.py /data/DLKcat.tsv /data/DLKcatOutput.tsv&quot;'</span>]);
 0039 
 0040 <span class="keyword">if</span> status == 0 &amp;&amp; exist(fullfile(params.path,<span class="string">'data/DLKcatOutput.tsv'</span>))
 0041     delete(fullfile(params.path,<span class="string">'/data/DLKcat.tsv'</span>));

--- a/src/geckomat/gather_kcats/runDLKcat.m
+++ b/src/geckomat/gather_kcats/runDLKcat.m
@@ -35,7 +35,7 @@ if checks.docker.status ~= 0
 end
 
 disp('Running DLKcat prediction, this may take many minutes, especially the first time.')
-status = system(['docker run --rm -v ' fullfile(params.path,'/data') ':/data ghcr.io/sysbiochalmers/dlkcat-gecko:0.1 /bin/bash -c "python DLKcat.py /data/DLKcat.tsv /data/DLKcatOutput.tsv"']);
+status = system(['docker run --rm -v "' fullfile(params.path,'/data') '":/data ghcr.io/sysbiochalmers/dlkcat-gecko:0.1 /bin/bash -c "python DLKcat.py /data/DLKcat.tsv /data/DLKcatOutput.tsv"']);
 
 if status == 0 && exist(fullfile(params.path,'data/DLKcatOutput.tsv'))
     delete(fullfile(params.path,'/data/DLKcat.tsv'));


### PR DESCRIPTION
### Main improvements in this PR:
- Fixes:
  - `runDLKcat` correctly handles `param.path` if the folder name has spaces (solves #351)

#### Instructions on merging this PR:
<!-- Chose ONE of the following two options
and replace [ ] with [X] to check the box.-->
- [X] This PR has `develop` as target branch, and will be resolved with a *squash-merge*.
- [ ] This PR has `main` as target branch, and will be resolved with a *merge commit*.
