### PR TITLE
fix: save ec model xml

### DIFF
--- a/src/geckomat/utilities/saveEcModel.m
+++ b/src/geckomat/utilities/saveEcModel.m
@@ -40,12 +40,12 @@ ecModel.description = ['Enzyme-constrained model of ' ecModel.id];
 
 switch filename(end-3:end)
     case {'.xml','sbml'}
-        exportModel(ecModel,[filename '.xml']);
+        exportModel(ecModel, filename);
         %Convert notation "e-005" to "e-05 " in stoich. coeffs. to avoid
         %inconsistencies between Windows and MAC:
-        copyfile([filename '.xml'],'backup.xml')
+        copyfile(filename,'backup.xml')
         fin  = fopen('backup.xml', 'r');
-        fout = fopen([filename '.xml'], 'w');
+        fout = fopen(filename, 'w');
         still_reading = true;
         while still_reading
             inline = fgets(fin);

--- a/tutorials/light_ecModel/protocol.m
+++ b/tutorials/light_ecModel/protocol.m
@@ -74,7 +74,7 @@ kcatList_DLKcat = readDLKcatOutput(ecModel);
 % STEP 26 Merge BRENDA and DLKcat derived values
 kcatList_merged = mergeDLKcatAndFuzzyKcats(kcatList_DLKcat, kcatList_fuzzy);
 
-% STEP 27 Implement kcat avlues into model.ec.kcat
+% STEP 27 Implement kcat values into model.ec.kcat
 ecModel = selectKcatValue(ecModel,kcatList_merged);
 
 % STEP 28
@@ -96,7 +96,7 @@ ecModel = selectKcatValue(ecModel,kcatList_merged);
 % -standardMW/standardKcat as the stoiciometric coefficient.
 [ecModel, rxnsMissingGPR, standardMW, standardKcat] = getStandardKcat(ecModel);
 
-% STEP 31 Apply kcat avlues to S-matrix
+% STEP 31 Apply kcat values to S-matrix
 % In light ecModels the kcat values are also kept in ecModels.ec.kcat, and
 % only after running applyKcatConstraints are these introduced in the
 % ecModel.S matrix. In constrast to full ecModels, the applyKcatConstraints


### PR DESCRIPTION
### Main improvements in this PR:
<!-- Pointwise mention what changes were made in what function. Examples: 
- Fixes:
  - `functionName` failed to do function X
- Documentation:
  - updated all documentation 
- Features:
  - Introduced option to do function Y (issue #12345) -->
This PR aims to resolve a bug where `.xml` was unnecessarily appended to a filename that already ended with `.xml` when saving an EC model. Also, a typo has been also fixed.

#### Instructions on merging this PR:
<!-- Chose ONE of the following two options
and replace [ ] with [X] to check the box.-->
- [x] This PR has `develop` as target branch, and will be resolved with a *squash-merge*.
- [ ] This PR has `main` as target branch, and will be resolved with a *merge commit*.
