### PR TITLE
feat: support for alternative location of DLKcat in/output

### DIFF
--- a/doc/src/geckomat/gather_kcats/readDLKcatOutput.html
+++ b/doc/src/geckomat/gather_kcats/readDLKcatOutput.html
@@ -34,10 +34,9 @@
 
  Input:
    model           an ecModel in GECKO 3 format (with ecModel.ec structure)
-   outFile         name and path of the DLKcat output file. If nothing is
-                   provided, an attempt will be made to read
-                   data/DLKcat.tsv from the obj.params.path folder
-                   specified in the modelAdapter.
+   outFile         name and path of the DLKcat output file. (Optional,
+                   default is data/DLKcat.tsv from the obj.params.path
+                   folder specified in the modelAdapter)
    modelAdapter    a loaded model adapter (Optional, will otherwise use the
                    default model adapter).
 
@@ -74,77 +73,76 @@ This function is called by:
 0006 <span class="comment">%</span>
 0007 <span class="comment">% Input:</span>
 0008 <span class="comment">%   model           an ecModel in GECKO 3 format (with ecModel.ec structure)</span>
-0009 <span class="comment">%   outFile         name and path of the DLKcat output file. If nothing is</span>
-0010 <span class="comment">%                   provided, an attempt will be made to read</span>
-0011 <span class="comment">%                   data/DLKcat.tsv from the obj.params.path folder</span>
-0012 <span class="comment">%                   specified in the modelAdapter.</span>
-0013 <span class="comment">%   modelAdapter    a loaded model adapter (Optional, will otherwise use the</span>
-0014 <span class="comment">%                   default model adapter).</span>
-0015 <span class="comment">%</span>
-0016 <span class="comment">% Output:</span>
-0017 <span class="comment">%   kcatList    structure array with list of DLKcat derived kcat values,</span>
-0018 <span class="comment">%               with separate entries for each kcat value</span>
-0019 <span class="comment">%               source      'DLKcat'</span>
-0020 <span class="comment">%               rxns        reaction identifiers</span>
-0021 <span class="comment">%               genes       gene identifiers</span>
-0022 <span class="comment">%               substrate   substrate names</span>
-0023 <span class="comment">%               kcat        predicted kcat value in /sec</span>
-0024 <span class="comment">%</span>
-0025 <span class="comment">% Usage:</span>
-0026 <span class="comment">%   kcatList = readDLKcatOutput(model, outFile, modelAdapter)</span>
-0027 
-0028 <span class="keyword">if</span> nargin &lt; 3 || isempty(modelAdapter)
-0029     modelAdapter = ModelAdapterManager.getDefault();
-0030     <span class="keyword">if</span> isempty(modelAdapter)
-0031         error(<span class="string">'Either send in a modelAdapter or set the default model adapter in the ModelAdapterManager.'</span>)
-0032     <span class="keyword">end</span>
-0033 <span class="keyword">end</span>
-0034 params = modelAdapter.params;
-0035 
-0036 <span class="keyword">if</span> nargin&lt;2 || isempty(outFile)
-0037     fID      = fopen(fullfile(params.path,<span class="string">'data'</span>,<span class="string">'DLKcat.tsv'</span>),<span class="string">'r'</span>);
-0038 <span class="keyword">else</span>
-0039     fID      = fopen(outFile);
-0040 <span class="keyword">end</span>
-0041 DLKcatOutput = textscan(fID,<span class="string">'%s %s %s %s %s %s'</span>,<span class="string">'Delimiter'</span>,<span class="string">'\t'</span>,<span class="string">'HeaderLines'</span>,1);
-0042 fclose(fID);
-0043 
-0044 <span class="comment">% Check that DLKcat output file and model match (not fool proof, but good enough)</span>
-0045 [rxns, genes, subs, kcats] = deal(DLKcatOutput{[1,2,3,6]});
-0046 
-0047 <span class="comment">% Check if it contains any kcat values</span>
-0048 <span class="keyword">if</span> all(cellfun(@isempty,kcats)) || all(strcmpi(kcats,<span class="string">'NA'</span>))
-0049     error(<span class="string">'DLKcat file does not contain any kcat values, please run runDLKcat() first.'</span>)
-0050 <span class="keyword">end</span>
-0051 
-0052 <span class="comment">% Check that all substrates are in the model</span>
-0053 matchMets = ismember(subs,model.metNames);
-0054 <span class="keyword">if</span> ~all(matchMets)
-0055     errorText = <span class="string">'DLKcat was likely run with an input file that was generated from another ecModel, as the following substrates from DLKcat output cannot be found in model.metNames:'</span>;
-0056     dispEM(errorText,true,subs(~matchMets),false)
-0057 <span class="keyword">end</span>
-0058 
-0059 <span class="comment">% Check that all reactions are in model.ec.rxns</span>
-0060 matchRxns = ismember(rxns,model.ec.rxns);
-0061 <span class="keyword">if</span> ~all(matchRxns)
-0062     errorText = <span class="string">'DLKcat was likely run with an input file that was generated from another ecModel, as the following reactions from DLKcat output cannot be found in model.metNames:'</span>;
-0063     dispEM(errorText,true,rxns(~matchRxns),false)
-0064 <span class="keyword">end</span>
-0065 
-0066 <span class="comment">% Filter out entries with no numeric value</span>
-0067 noOutput        = cellfun(@isempty,regexpi(kcats,<span class="string">'[0-9]'</span>));
-0068 kcats           = str2double(kcats(~noOutput));
-0069 rxns(noOutput)  = [];
-0070 genes(noOutput) = [];
-0071 subs(noOutput)  = [];
-0072 
-0073 <span class="comment">% Make kcatList structure</span>
-0074 kcatList.source     = <span class="string">'DLKcat'</span>;
-0075 kcatList.rxns       = rxns;
-0076 kcatList.genes      = genes;
-0077 kcatList.substrates = subs;
-0078 kcatList.kcats      = kcats;
-0079 <span class="keyword">end</span></pre></div>
+0009 <span class="comment">%   outFile         name and path of the DLKcat output file. (Optional,</span>
+0010 <span class="comment">%                   default is data/DLKcat.tsv from the obj.params.path</span>
+0011 <span class="comment">%                   folder specified in the modelAdapter)</span>
+0012 <span class="comment">%   modelAdapter    a loaded model adapter (Optional, will otherwise use the</span>
+0013 <span class="comment">%                   default model adapter).</span>
+0014 <span class="comment">%</span>
+0015 <span class="comment">% Output:</span>
+0016 <span class="comment">%   kcatList    structure array with list of DLKcat derived kcat values,</span>
+0017 <span class="comment">%               with separate entries for each kcat value</span>
+0018 <span class="comment">%               source      'DLKcat'</span>
+0019 <span class="comment">%               rxns        reaction identifiers</span>
+0020 <span class="comment">%               genes       gene identifiers</span>
+0021 <span class="comment">%               substrate   substrate names</span>
+0022 <span class="comment">%               kcat        predicted kcat value in /sec</span>
+0023 <span class="comment">%</span>
+0024 <span class="comment">% Usage:</span>
+0025 <span class="comment">%   kcatList = readDLKcatOutput(model, outFile, modelAdapter)</span>
+0026 
+0027 <span class="keyword">if</span> nargin &lt; 3 || isempty(modelAdapter)
+0028     modelAdapter = ModelAdapterManager.getDefault();
+0029     <span class="keyword">if</span> isempty(modelAdapter)
+0030         error(<span class="string">'Either send in a modelAdapter or set the default model adapter in the ModelAdapterManager.'</span>)
+0031     <span class="keyword">end</span>
+0032 <span class="keyword">end</span>
+0033 params = modelAdapter.params;
+0034 
+0035 <span class="keyword">if</span> nargin&lt;2 || isempty(outFile)
+0036     fID      = fopen(fullfile(params.path,<span class="string">'data'</span>,<span class="string">'DLKcat.tsv'</span>),<span class="string">'r'</span>);
+0037 <span class="keyword">else</span>
+0038     fID      = fopen(outFile);
+0039 <span class="keyword">end</span>
+0040 DLKcatOutput = textscan(fID,<span class="string">'%s %s %s %s %s %s'</span>,<span class="string">'Delimiter'</span>,<span class="string">'\t'</span>,<span class="string">'HeaderLines'</span>,1);
+0041 fclose(fID);
+0042 
+0043 <span class="comment">% Check that DLKcat output file and model match (not fool proof, but good enough)</span>
+0044 [rxns, genes, subs, kcats] = deal(DLKcatOutput{[1,2,3,6]});
+0045 
+0046 <span class="comment">% Check if it contains any kcat values</span>
+0047 <span class="keyword">if</span> all(cellfun(@isempty,kcats)) || all(strcmpi(kcats,<span class="string">'NA'</span>))
+0048     error(<span class="string">'DLKcat file does not contain any kcat values, please run runDLKcat() first.'</span>)
+0049 <span class="keyword">end</span>
+0050 
+0051 <span class="comment">% Check that all substrates are in the model</span>
+0052 matchMets = ismember(subs,model.metNames);
+0053 <span class="keyword">if</span> ~all(matchMets)
+0054     errorText = <span class="string">'DLKcat was likely run with an input file that was generated from another ecModel, as the following substrates from DLKcat output cannot be found in model.metNames:'</span>;
+0055     dispEM(errorText,true,subs(~matchMets),false)
+0056 <span class="keyword">end</span>
+0057 
+0058 <span class="comment">% Check that all reactions are in model.ec.rxns</span>
+0059 matchRxns = ismember(rxns,model.ec.rxns);
+0060 <span class="keyword">if</span> ~all(matchRxns)
+0061     errorText = <span class="string">'DLKcat was likely run with an input file that was generated from another ecModel, as the following reactions from DLKcat output cannot be found in model.metNames:'</span>;
+0062     dispEM(errorText,true,rxns(~matchRxns),false)
+0063 <span class="keyword">end</span>
+0064 
+0065 <span class="comment">% Filter out entries with no numeric value</span>
+0066 noOutput        = cellfun(@isempty,regexpi(kcats,<span class="string">'[0-9]'</span>));
+0067 kcats           = str2double(kcats(~noOutput));
+0068 rxns(noOutput)  = [];
+0069 genes(noOutput) = [];
+0070 subs(noOutput)  = [];
+0071 
+0072 <span class="comment">% Make kcatList structure</span>
+0073 kcatList.source     = <span class="string">'DLKcat'</span>;
+0074 kcatList.rxns       = rxns;
+0075 kcatList.genes      = genes;
+0076 kcatList.substrates = subs;
+0077 kcatList.kcats      = kcats;
+0078 <span class="keyword">end</span></pre></div>
 <hr><address>Generated by <strong><a href="http://www.artefact.tk/software/matlab/m2html/" title="Matlab Documentation in HTML">m2html</a></strong> &copy; 2005</address>
 </body>
 </html>

--- a/doc/src/geckomat/gather_kcats/runDLKcat.html
+++ b/doc/src/geckomat/gather_kcats/runDLKcat.html
@@ -24,7 +24,7 @@
 <div class="box"><strong>runDLKcat</strong></div>
 
 <h2><a name="_synopsis"></a>SYNOPSIS <a href="#_top"><img alt="^" border="0" src="../../../up.png"></a></h2>
-<div class="box"><strong>function runDLKcat(modelAdapter) </strong></div>
+<div class="box"><strong>function runDLKcat(modelAdapter,filePath) </strong></div>
 
 <h2><a name="_description"></a>DESCRIPTION <a href="#_top"><img alt="^" border="0" src="../../../up.png"></a></h2>
 <div class="fragment"><pre class="comment"> runDLKcat
@@ -36,6 +36,8 @@
  Input
    modelAdapter    a loaded model adapter. (Optional, will otherwise use
                    the default model adapter)
+   filePath        path to the DLKcat.tsv file. (Optional, will otherwise
+                   assume data/DLKcat.tsv)
 
    NOTE: 1. Requires Docker to be installed, and Docker Desktop running. Visit &quot;https://www.docker.com&quot;
          2. Runtime will depend on whether the image is to be downloaded or not.</pre></div>
@@ -53,7 +55,7 @@ This function is called by:
 
 
 <h2><a name="_source"></a>SOURCE CODE <a href="#_top"><img alt="^" border="0" src="../../../up.png"></a></h2>
-<div class="fragment"><pre>0001 <a name="_sub0" href="#_subfunctions" class="code">function runDLKcat(modelAdapter)</a>
+<div class="fragment"><pre>0001 <a name="_sub0" href="#_subfunctions" class="code">function runDLKcat(modelAdapter,filePath)</a>
 0002 <span class="comment">% runDLKcat</span>
 0003 <span class="comment">%   Runs DLKcat to predict kcat values from a Docker image. Once DLKcat is succesfully</span>
 0004 <span class="comment">%   run, the DLKcatFile will be overwritten with the DLKcat</span>
@@ -63,46 +65,57 @@ This function is called by:
 0008 <span class="comment">% Input</span>
 0009 <span class="comment">%   modelAdapter    a loaded model adapter. (Optional, will otherwise use</span>
 0010 <span class="comment">%                   the default model adapter)</span>
-0011 <span class="comment">%</span>
-0012 <span class="comment">%   NOTE: 1. Requires Docker to be installed, and Docker Desktop running. Visit &quot;https://www.docker.com&quot;</span>
-0013 <span class="comment">%         2. Runtime will depend on whether the image is to be downloaded or not.</span>
-0014 
-0015 <span class="keyword">if</span> nargin &lt; 1 || isempty(modelAdapter)
-0016     modelAdapter = ModelAdapterManager.getDefault();
-0017     <span class="keyword">if</span> isempty(modelAdapter)
-0018         error(<span class="string">'Either send in a modelAdapter or set the default model adapter in the ModelAdapterManager.'</span>)
-0019     <span class="keyword">end</span>
-0020 <span class="keyword">end</span>
-0021 
-0022 params = modelAdapter.params;
-0023 <span class="comment">% Make sure path is full, not relative</span>
-0024 [~, params.path] = fileattrib(params.path);
-0025 params.path=params.path.Name;
-0026 
-0027 <span class="comment">%% Check and install requirements</span>
-0028 <span class="comment">% On macOS, Docker might not be properly loaded if MATLAB is started via</span>
-0029 <span class="comment">% launcher and not terminal.</span>
-0030 <span class="keyword">if</span> ismac
-0031     setenv(<span class="string">'PATH'</span>, strcat(<span class="string">'/usr/local/bin'</span>, <span class="string">':'</span>, getenv(&quot;PATH&quot;)));
+0011 <span class="comment">%   filePath        path to the DLKcat.tsv file. (Optional, will otherwise</span>
+0012 <span class="comment">%                   assume data/DLKcat.tsv)</span>
+0013 <span class="comment">%</span>
+0014 <span class="comment">%   NOTE: 1. Requires Docker to be installed, and Docker Desktop running. Visit &quot;https://www.docker.com&quot;</span>
+0015 <span class="comment">%         2. Runtime will depend on whether the image is to be downloaded or not.</span>
+0016 
+0017 <span class="keyword">if</span> nargin &lt; 1 || isempty(modelAdapter)
+0018     modelAdapter = ModelAdapterManager.getDefault();
+0019     <span class="keyword">if</span> isempty(modelAdapter)
+0020         error(<span class="string">'Either send in a modelAdapter or set the default model adapter in the ModelAdapterManager.'</span>)
+0021     <span class="keyword">end</span>
+0022 <span class="keyword">end</span>
+0023 params = modelAdapter.params;
+0024 <span class="comment">% Make sure path is full, not relative</span>
+0025 [~, params.path] = fileattrib(params.path);
+0026 params.path=params.path.Name;
+0027 
+0028 <span class="keyword">if</span> nargin &lt; 2 || isempty(filePath)
+0029     filePath = fullfile(params.path,<span class="string">'data'</span>,<span class="string">'DLKcat.tsv'</span>);
+0030 <span class="keyword">elseif</span> strcmp(filePath(end),{<span class="string">'\'</span>,<span class="string">'/'</span>})
+0031     filePath = fullfile(filePath,<span class="string">'DLKcat.tsv'</span>);
 0032 <span class="keyword">end</span>
-0033 
-0034 <span class="comment">% Check if Docker is installed</span>
-0035 [checks.docker.status, checks.docker.out] = system(<span class="string">'docker --version'</span>);
-0036 <span class="keyword">if</span> checks.docker.status ~= 0
-0037     error(<span class="string">'Cannot find Docker, make sure it is installed. If it is, it might be required to start Matlab from the command-line instead of the launcher in order for Docker to be detected and used.'</span>)
-0038 <span class="keyword">end</span>
-0039 
-0040 disp(<span class="string">'Running DLKcat prediction, this may take many minutes, especially the first time.'</span>)
-0041 status = system([<span class="string">'docker run --rm -v &quot;'</span> fullfile(params.path,<span class="string">'/data'</span>) <span class="string">'&quot;:/data ghcr.io/sysbiochalmers/dlkcat-gecko:0.1 /bin/bash -c &quot;python DLKcat.py /data/DLKcat.tsv /data/DLKcatOutput.tsv&quot;'</span>]);
-0042 
-0043 <span class="keyword">if</span> status == 0 &amp;&amp; exist(fullfile(params.path,<span class="string">'data/DLKcatOutput.tsv'</span>))
-0044     delete(fullfile(params.path,<span class="string">'/data/DLKcat.tsv'</span>));
-0045     movefile(fullfile(params.path,<span class="string">'/data/DLKcatOutput.tsv'</span>), fullfile(params.path,<span class="string">'/data/DLKcat.tsv'</span>));
-0046     disp(<span class="string">'DKLcat prediction completed.'</span>);
-0047 <span class="keyword">else</span>    
-0048     error(<span class="string">'DLKcat encountered an error or it did not create any output file.'</span>)
+0033 filePath = checkFileExistence(filePath,1);
+0034 
+0035 copyfile(filePath, fullfile(params.path,<span class="string">'data'</span>,<span class="string">'tempDLKcat.tsv'</span>));
+0036     
+0037 
+0038 <span class="comment">%% Check and install requirements</span>
+0039 <span class="comment">% On macOS, Docker might not be properly loaded if MATLAB is started via</span>
+0040 <span class="comment">% launcher and not terminal.</span>
+0041 <span class="keyword">if</span> ismac
+0042     setenv(<span class="string">'PATH'</span>, strcat(<span class="string">'/usr/local/bin'</span>, <span class="string">':'</span>, getenv(&quot;PATH&quot;)));
+0043 <span class="keyword">end</span>
+0044 
+0045 <span class="comment">% Check if Docker is installed</span>
+0046 [checks.docker.status, checks.docker.out] = system(<span class="string">'docker --version'</span>);
+0047 <span class="keyword">if</span> checks.docker.status ~= 0
+0048     error(<span class="string">'Cannot find Docker, make sure it is installed. If it is, it might be required to start Matlab from the command-line instead of the launcher in order for Docker to be detected and used.'</span>)
 0049 <span class="keyword">end</span>
-0050</pre></div>
+0050 
+0051 disp(<span class="string">'Running DLKcat prediction, this may take many minutes, especially the first time.'</span>)
+0052 status = system([<span class="string">'docker run --rm -v &quot;'</span> fullfile(params.path,<span class="string">'/data'</span>) <span class="string">'&quot;:/data ghcr.io/sysbiochalmers/dlkcat-gecko:0.1 /bin/bash -c &quot;python DLKcat.py /data/tempDLKcat.tsv /data/tempDLKcatOutput.tsv&quot;'</span>]);
+0053 delete(fullfile(params.path,<span class="string">'/data/tempDLKcat.tsv'</span>));
+0054 
+0055 <span class="keyword">if</span> status == 0 &amp;&amp; exist(fullfile(params.path,<span class="string">'data/tempDLKcatOutput.tsv'</span>))
+0056     movefile(fullfile(params.path,<span class="string">'/data/tempDLKcatOutput.tsv'</span>), filePath);
+0057     disp(<span class="string">'DKLcat prediction completed.'</span>);
+0058 <span class="keyword">else</span>    
+0059     error(<span class="string">'DLKcat encountered an error or it did not create any output file.'</span>)
+0060 <span class="keyword">end</span>
+0061</pre></div>
 <hr><address>Generated by <strong><a href="http://www.artefact.tk/software/matlab/m2html/" title="Matlab Documentation in HTML">m2html</a></strong> &copy; 2005</address>
 </body>
 </html>

--- a/doc/src/geckomat/gather_kcats/writeDLKcatInput.html
+++ b/doc/src/geckomat/gather_kcats/writeDLKcatInput.html
@@ -41,8 +41,9 @@
                    default model adapter).
    onlyWithSmiles  logical whether to only include metabolites with SMILES
                    (optional, default true)
-   filename        Filename (Optional). Normally this parameter should not be 
-                   supplied, but it is useful for test cases.
+   filename        path to the input file, including the filename and .tsv
+                   extension (Optional, default is data/DLKcat.tsv from
+                   the obj.params.path folder specified in the modelAdapter)
    overwrite       logical whether existing file should be overwritten.
                    (Optional, default false, to prevent overwriting file
                    that already contains DLKcat-predicted kcat values).
@@ -81,153 +82,156 @@ This function is called by:
 0013 <span class="comment">%                   default model adapter).</span>
 0014 <span class="comment">%   onlyWithSmiles  logical whether to only include metabolites with SMILES</span>
 0015 <span class="comment">%                   (optional, default true)</span>
-0016 <span class="comment">%   filename        Filename (Optional). Normally this parameter should not be</span>
-0017 <span class="comment">%                   supplied, but it is useful for test cases.</span>
-0018 <span class="comment">%   overwrite       logical whether existing file should be overwritten.</span>
-0019 <span class="comment">%                   (Optional, default false, to prevent overwriting file</span>
-0020 <span class="comment">%                   that already contains DLKcat-predicted kcat values).</span>
-0021 <span class="comment">%</span>
-0022 <span class="comment">% Output:</span>
-0023 <span class="comment">%   writtenTable    The table written, mainly to be used for testing purposes.</span>
-0024 <span class="comment">%</span>
-0025 <span class="comment">% Usage:</span>
-0026 <span class="comment">%   writtenTable = writeDLKcatInput(model, ecRxns, modelAdapter, onlyWithSmiles, filename, overwrite)</span>
-0027 
-0028 [geckoPath, ~] = findGECKOroot();
-0029 
-0030 <span class="keyword">if</span> nargin&lt;2 || isempty(ecRxns)
-0031     ecRxns = true(numel(model.ec.rxns),1);
-0032 <span class="keyword">elseif</span> ~logical(ecRxns)
-0033     error(<span class="string">'ecRxns should be provided as logical vector'</span>)
-0034 <span class="keyword">elseif</span> numel(ecRxns)~=numel(model.ec.rxns)
-0035     error(<span class="string">'Length of ecRxns is not the same as model.ec.rxns'</span>)
-0036 <span class="keyword">end</span>
-0037 ecRxns = find(ecRxns); <span class="comment">% Change to indices</span>
-0038 
-0039 <span class="keyword">if</span> nargin &lt; 3 || isempty(modelAdapter)
-0040     modelAdapter = ModelAdapterManager.getDefault();
-0041     <span class="keyword">if</span> isempty(modelAdapter)
-0042         error(<span class="string">'Either send in a modelAdapter or set the default model adapter in the ModelAdapterManager.'</span>)
-0043     <span class="keyword">end</span>
-0044 <span class="keyword">end</span>
-0045 params = modelAdapter.params;
-0046 
-0047 <span class="keyword">if</span> nargin&lt;4 || isempty(onlyWithSmiles)
-0048     onlyWithSmiles=true;
-0049 <span class="keyword">end</span>
-0050 
-0051 <span class="keyword">if</span> nargin&lt;5 || isempty(filename)
-0052     filename = fullfile(params.path,<span class="string">'data'</span>,<span class="string">'DLKcat.tsv'</span>);
-0053 <span class="keyword">end</span>
-0054 
-0055 <span class="keyword">if</span> nargin&lt;6 || isempty(overwrite) || ~overwrite <span class="comment">% If is true</span>
-0056     <span class="keyword">if</span> exist(filename,<span class="string">'file'</span>)
-0057         error([filename <span class="string">' already exists, either delete it first, or set the overwrite input argument as true'</span>])
-0058     <span class="keyword">end</span>
-0059 <span class="keyword">end</span>
-0060 
-0061 <span class="keyword">if</span> ~model.ec.geckoLight
-0062    origRxns = model.ec.rxns;
-0063 <span class="keyword">else</span>
-0064    origRxns = extractAfter(model.ec.rxns,4);
-0065 <span class="keyword">end</span>
-0066 origRxnsToInclude = origRxns(ecRxns);
-0067 
-0068 <span class="comment">% Map back to original reactions, to extract substrates</span>
-0069 [sanityCheck,origRxnIdxs] = ismember(origRxnsToInclude,model.rxns);
-0070 <span class="keyword">if</span> ~all(sanityCheck)
-0071     error(<span class="string">'Not all reactions in model.ec.rxns are found in model.rxns'</span>)
-0072 <span class="keyword">end</span>
-0073 
-0074 <span class="comment">% Ignore selected metabolites (metal ions, proteins etc.). First check by</span>
-0075 <span class="comment">% name (case insensitive, without white spaces and special characters),</span>
-0076 <span class="comment">% then also try to match with metSmiles (if available).</span>
-0077 metsNoSpecialChars = lower(regexprep(model.metNames,<span class="string">'[^0-9a-zA-Z]+'</span>,<span class="string">''</span>));
-0078 <span class="keyword">if</span> exist(fullfile(params.path,<span class="string">'data'</span>,<span class="string">'DLKcatIgnoreMets.tsv'</span>),<span class="string">'file'</span>)
-0079     fID        = fopen(fullfile(params.path,<span class="string">'data'</span>,<span class="string">'DLKcatIgnoreMets.tsv'</span>));
-0080 <span class="keyword">else</span>
-0081     fID        = fopen(fullfile(geckoPath,<span class="string">'databases'</span>,<span class="string">'DLKcatIgnoreMets.tsv'</span>));
-0082 <span class="keyword">end</span>
-0083 fileData   = textscan(fID,<span class="string">'%s %s'</span>,<span class="string">'delimiter'</span>,<span class="string">'\t'</span>);
-0084 fclose(fID);
-0085 [ignoreMets, ignoreSmiles] = deal(fileData{[1,2]});
-0086 ignoreMets = lower(regexprep(ignoreMets,<span class="string">'[^0-9a-zA-Z]+'</span>,<span class="string">''</span>));
-0087 ignoreSmiles(cellfun(@isempty,ignoreSmiles)) = [];
-0088 
-0089 ignoreMetsIdx  = logical(ismember(metsNoSpecialChars,ignoreMets));
-0090 <span class="keyword">if</span> isfield(model,<span class="string">'metSmiles'</span>)
-0091     ignoreMetsIdx = ignoreMetsIdx | logical(ismember(model.metSmiles,ignoreSmiles));
-0092 <span class="keyword">end</span>
-0093 <span class="comment">% Also leave out protein-usage pseudometabolites</span>
-0094 ignoreMetsIdx = ignoreMetsIdx | startsWith(model.mets,<span class="string">'prot_'</span>);
-0095 reducedS = model.S;
-0096 reducedS(ignoreMetsIdx,:) = 0;
-0097 
-0098 <span class="comment">% Ignore currency metabolites if they occur in pairs. First check by</span>
-0099 <span class="comment">% name (case insensitive, without white spaces and special characters),</span>
-0100 <span class="comment">% then also try to match with metSmiles (if available).</span>
-0101 <span class="keyword">if</span> exist(fullfile(params.path,<span class="string">'data'</span>,<span class="string">'DLKcatCurrencyMets.tsv'</span>),<span class="string">'file'</span>)
-0102     fID = fopen(fullfile(params.path,<span class="string">'data'</span>,<span class="string">'DLKcatCurrencyMets.tsv'</span>));
-0103 <span class="keyword">else</span>
-0104     fID = fopen(fullfile(geckoPath,<span class="string">'databases'</span>,<span class="string">'DLKcatCurrencyMets.tsv'</span>));
-0105 <span class="keyword">end</span>
-0106 fileData = textscan(fID,<span class="string">'%s %s'</span>,<span class="string">'delimiter'</span>,<span class="string">'\t'</span>);
-0107 fclose(fID);
-0108 [currencyMets(:,1), currencyMets(:,2)] = deal(fileData{[1,2]});
-0109 currencyMets = lower(regexprep(currencyMets,<span class="string">'[^0-9a-zA-Z]+'</span>,<span class="string">''</span>));
-0110 
-0111 <span class="keyword">for</span> i=1:size(currencyMets,1)
-0112     subs = strcmp(currencyMets(i,1),metsNoSpecialChars);
-0113     prod = strcmp(currencyMets(i,2),metsNoSpecialChars);
-0114     [~,subsRxns]=find(reducedS(subs,:));
-0115     [~,prodRxns]=find(reducedS(prod,:));
-0116     pairRxns = intersect(subsRxns,prodRxns);
-0117     tempRedS=reducedS;
-0118     tempRedS([find(subs);find(prod)],pairRxns) = 0;
-0119     <span class="comment">% Do not remove currency mets if no substrate remains</span>
-0120     rxnsWithRemainingSubstrates = any(tempRedS(:,pairRxns) &lt; 0,1);
-0121     reducedS([find(subs);find(prod)],intersect(pairRxns,pairRxns(rxnsWithRemainingSubstrates))) = 0;
-0122 <span class="keyword">end</span>
-0123 
-0124 <span class="comment">%filter out the reactions we're not interested in - will solve the problem for both full and light</span>
-0125 clearedRedS = reducedS(:,origRxnIdxs);
-0126 rxnsToClear = true(length(origRxnIdxs),1);
-0127 rxnsToClear(ecRxns) = false;
-0128 clearedRedS(:,rxnsToClear) = 0;
-0129 
-0130 <span class="comment">% Enumerate all substrates for each reaction</span>
-0131 [substrates, reactions] = find(clearedRedS&lt;0); <span class="comment">%the reactions here are in model.ec.rxns space</span>
+0016 <span class="comment">%   filename        path to the input file, including the filename and .tsv</span>
+0017 <span class="comment">%                   extension (Optional, default is data/DLKcat.tsv from</span>
+0018 <span class="comment">%                   the obj.params.path folder specified in the modelAdapter)</span>
+0019 <span class="comment">%   overwrite       logical whether existing file should be overwritten.</span>
+0020 <span class="comment">%                   (Optional, default false, to prevent overwriting file</span>
+0021 <span class="comment">%                   that already contains DLKcat-predicted kcat values).</span>
+0022 <span class="comment">%</span>
+0023 <span class="comment">% Output:</span>
+0024 <span class="comment">%   writtenTable    The table written, mainly to be used for testing purposes.</span>
+0025 <span class="comment">%</span>
+0026 <span class="comment">% Usage:</span>
+0027 <span class="comment">%   writtenTable = writeDLKcatInput(model, ecRxns, modelAdapter, onlyWithSmiles, filename, overwrite)</span>
+0028 
+0029 [geckoPath, ~] = findGECKOroot();
+0030 
+0031 <span class="keyword">if</span> nargin&lt;2 || isempty(ecRxns)
+0032     ecRxns = true(numel(model.ec.rxns),1);
+0033 <span class="keyword">elseif</span> ~logical(ecRxns)
+0034     error(<span class="string">'ecRxns should be provided as logical vector'</span>)
+0035 <span class="keyword">elseif</span> numel(ecRxns)~=numel(model.ec.rxns)
+0036     error(<span class="string">'Length of ecRxns is not the same as model.ec.rxns'</span>)
+0037 <span class="keyword">end</span>
+0038 ecRxns = find(ecRxns); <span class="comment">% Change to indices</span>
+0039 
+0040 <span class="keyword">if</span> nargin &lt; 3 || isempty(modelAdapter)
+0041     modelAdapter = ModelAdapterManager.getDefault();
+0042     <span class="keyword">if</span> isempty(modelAdapter)
+0043         error(<span class="string">'Either send in a modelAdapter or set the default model adapter in the ModelAdapterManager.'</span>)
+0044     <span class="keyword">end</span>
+0045 <span class="keyword">end</span>
+0046 params = modelAdapter.params;
+0047 
+0048 <span class="keyword">if</span> nargin&lt;4 || isempty(onlyWithSmiles)
+0049     onlyWithSmiles=true;
+0050 <span class="keyword">end</span>
+0051 
+0052 <span class="keyword">if</span> nargin&lt;5 || isempty(filename)
+0053     filename = fullfile(params.path,<span class="string">'data'</span>,<span class="string">'DLKcat.tsv'</span>);
+0054 <span class="keyword">elseif</span> ~endsWith(filename,<span class="string">'.tsv'</span>)
+0055     error(<span class="string">'If filename is provided, it should include the .tsv extension.'</span>)
+0056 <span class="keyword">end</span>
+0057 
+0058 <span class="keyword">if</span> nargin&lt;6 || isempty(overwrite) || ~overwrite <span class="comment">% If is true</span>
+0059     <span class="keyword">if</span> exist(filename,<span class="string">'file'</span>)
+0060         error([filename <span class="string">' already exists, either delete it first, or set the overwrite input argument as true'</span>])
+0061     <span class="keyword">end</span>
+0062 <span class="keyword">end</span>
+0063 
+0064 <span class="keyword">if</span> ~model.ec.geckoLight
+0065    origRxns = model.ec.rxns;
+0066 <span class="keyword">else</span>
+0067    origRxns = extractAfter(model.ec.rxns,4);
+0068 <span class="keyword">end</span>
+0069 origRxnsToInclude = origRxns(ecRxns);
+0070 
+0071 <span class="comment">% Map back to original reactions, to extract substrates</span>
+0072 [sanityCheck,origRxnIdxs] = ismember(origRxnsToInclude,model.rxns);
+0073 <span class="keyword">if</span> ~all(sanityCheck)
+0074     error(<span class="string">'Not all reactions in model.ec.rxns are found in model.rxns'</span>)
+0075 <span class="keyword">end</span>
+0076 
+0077 <span class="comment">% Ignore selected metabolites (metal ions, proteins etc.). First check by</span>
+0078 <span class="comment">% name (case insensitive, without white spaces and special characters),</span>
+0079 <span class="comment">% then also try to match with metSmiles (if available).</span>
+0080 metsNoSpecialChars = lower(regexprep(model.metNames,<span class="string">'[^0-9a-zA-Z]+'</span>,<span class="string">''</span>));
+0081 <span class="keyword">if</span> exist(fullfile(params.path,<span class="string">'data'</span>,<span class="string">'DLKcatIgnoreMets.tsv'</span>),<span class="string">'file'</span>)
+0082     fID        = fopen(fullfile(params.path,<span class="string">'data'</span>,<span class="string">'DLKcatIgnoreMets.tsv'</span>));
+0083 <span class="keyword">else</span>
+0084     fID        = fopen(fullfile(geckoPath,<span class="string">'databases'</span>,<span class="string">'DLKcatIgnoreMets.tsv'</span>));
+0085 <span class="keyword">end</span>
+0086 fileData   = textscan(fID,<span class="string">'%s %s'</span>,<span class="string">'delimiter'</span>,<span class="string">'\t'</span>);
+0087 fclose(fID);
+0088 [ignoreMets, ignoreSmiles] = deal(fileData{[1,2]});
+0089 ignoreMets = lower(regexprep(ignoreMets,<span class="string">'[^0-9a-zA-Z]+'</span>,<span class="string">''</span>));
+0090 ignoreSmiles(cellfun(@isempty,ignoreSmiles)) = [];
+0091 
+0092 ignoreMetsIdx  = logical(ismember(metsNoSpecialChars,ignoreMets));
+0093 <span class="keyword">if</span> isfield(model,<span class="string">'metSmiles'</span>)
+0094     ignoreMetsIdx = ignoreMetsIdx | logical(ismember(model.metSmiles,ignoreSmiles));
+0095 <span class="keyword">end</span>
+0096 <span class="comment">% Also leave out protein-usage pseudometabolites</span>
+0097 ignoreMetsIdx = ignoreMetsIdx | startsWith(model.mets,<span class="string">'prot_'</span>);
+0098 reducedS = model.S;
+0099 reducedS(ignoreMetsIdx,:) = 0;
+0100 
+0101 <span class="comment">% Ignore currency metabolites if they occur in pairs. First check by</span>
+0102 <span class="comment">% name (case insensitive, without white spaces and special characters),</span>
+0103 <span class="comment">% then also try to match with metSmiles (if available).</span>
+0104 <span class="keyword">if</span> exist(fullfile(params.path,<span class="string">'data'</span>,<span class="string">'DLKcatCurrencyMets.tsv'</span>),<span class="string">'file'</span>)
+0105     fID = fopen(fullfile(params.path,<span class="string">'data'</span>,<span class="string">'DLKcatCurrencyMets.tsv'</span>));
+0106 <span class="keyword">else</span>
+0107     fID = fopen(fullfile(geckoPath,<span class="string">'databases'</span>,<span class="string">'DLKcatCurrencyMets.tsv'</span>));
+0108 <span class="keyword">end</span>
+0109 fileData = textscan(fID,<span class="string">'%s %s'</span>,<span class="string">'delimiter'</span>,<span class="string">'\t'</span>);
+0110 fclose(fID);
+0111 [currencyMets(:,1), currencyMets(:,2)] = deal(fileData{[1,2]});
+0112 currencyMets = lower(regexprep(currencyMets,<span class="string">'[^0-9a-zA-Z]+'</span>,<span class="string">''</span>));
+0113 
+0114 <span class="keyword">for</span> i=1:size(currencyMets,1)
+0115     subs = strcmp(currencyMets(i,1),metsNoSpecialChars);
+0116     prod = strcmp(currencyMets(i,2),metsNoSpecialChars);
+0117     [~,subsRxns]=find(reducedS(subs,:));
+0118     [~,prodRxns]=find(reducedS(prod,:));
+0119     pairRxns = intersect(subsRxns,prodRxns);
+0120     tempRedS=reducedS;
+0121     tempRedS([find(subs);find(prod)],pairRxns) = 0;
+0122     <span class="comment">% Do not remove currency mets if no substrate remains</span>
+0123     rxnsWithRemainingSubstrates = any(tempRedS(:,pairRxns) &lt; 0,1);
+0124     reducedS([find(subs);find(prod)],intersect(pairRxns,pairRxns(rxnsWithRemainingSubstrates))) = 0;
+0125 <span class="keyword">end</span>
+0126 
+0127 <span class="comment">%filter out the reactions we're not interested in - will solve the problem for both full and light</span>
+0128 clearedRedS = reducedS(:,origRxnIdxs);
+0129 rxnsToClear = true(length(origRxnIdxs),1);
+0130 rxnsToClear(ecRxns) = false;
+0131 clearedRedS(:,rxnsToClear) = 0;
 0132 
-0133 <span class="comment">% Enumerate all proteins for each reaction</span>
-0134 [proteins, ecRxns] = find(transpose(model.ec.rxnEnzMat(reactions,:)));
+0133 <span class="comment">% Enumerate all substrates for each reaction</span>
+0134 [substrates, reactions] = find(clearedRedS&lt;0); <span class="comment">%the reactions here are in model.ec.rxns space</span>
 0135 
-0136 <span class="comment">% Prepare output</span>
-0137 out(1,:) = model.ec.rxns(reactions(ecRxns));
-0138 out(2,:) = model.ec.genes(proteins);
-0139 out(3,:) = model.metNames(substrates(ecRxns));
-0140 <span class="keyword">if</span> isfield(model,<span class="string">'metSmiles'</span>)
-0141     out(4,:) = model.metSmiles(substrates(ecRxns));
-0142 <span class="keyword">else</span>
-0143     out(4,:) = cell(numel(substrates(ecRxns)),1);
-0144 <span class="keyword">end</span>
-0145 
-0146 out(5,:) = model.ec.sequence(proteins);
-0147 <span class="keyword">if</span> onlyWithSmiles
-0148     out(:,cellfun(@isempty,out(4,:))) = [];
-0149 <span class="keyword">else</span>
-0150     out(4,cellfun(@isempty,out(4,:))) = {<span class="string">'None'</span>};
-0151 <span class="keyword">end</span>
-0152 out(6,:) = cell(numel(out(1,:)),1);
-0153 out(6,:) = {<span class="string">'NA'</span>};
-0154 
-0155 <span class="comment">% Write file</span>
-0156 fID = fopen(filename,<span class="string">'w'</span>);
-0157 fprintf(fID,<span class="string">'%s\t%s\t%s\t%s\t%s\t%s\n'</span>,out{:});
-0158 fclose(fID);
-0159 fprintf(<span class="string">'Model-specific DLKcat input stored at %s\n'</span>,filename);
-0160 
-0161 writtenTable = out;
-0162 <span class="keyword">end</span></pre></div>
+0136 <span class="comment">% Enumerate all proteins for each reaction</span>
+0137 [proteins, ecRxns] = find(transpose(model.ec.rxnEnzMat(reactions,:)));
+0138 
+0139 <span class="comment">% Prepare output</span>
+0140 out(1,:) = model.ec.rxns(reactions(ecRxns));
+0141 out(2,:) = model.ec.genes(proteins);
+0142 out(3,:) = model.metNames(substrates(ecRxns));
+0143 <span class="keyword">if</span> isfield(model,<span class="string">'metSmiles'</span>)
+0144     out(4,:) = model.metSmiles(substrates(ecRxns));
+0145 <span class="keyword">else</span>
+0146     out(4,:) = cell(numel(substrates(ecRxns)),1);
+0147 <span class="keyword">end</span>
+0148 
+0149 out(5,:) = model.ec.sequence(proteins);
+0150 <span class="keyword">if</span> onlyWithSmiles
+0151     out(:,cellfun(@isempty,out(4,:))) = [];
+0152 <span class="keyword">else</span>
+0153     out(4,cellfun(@isempty,out(4,:))) = {<span class="string">'None'</span>};
+0154 <span class="keyword">end</span>
+0155 out(6,:) = cell(numel(out(1,:)),1);
+0156 out(6,:) = {<span class="string">'NA'</span>};
+0157 
+0158 <span class="comment">% Write file</span>
+0159 fID = fopen(filename,<span class="string">'w'</span>);
+0160 fprintf(fID,<span class="string">'%s\t%s\t%s\t%s\t%s\t%s\n'</span>,out{:});
+0161 fclose(fID);
+0162 fprintf(<span class="string">'Model-specific DLKcat input stored at %s\n'</span>,filename);
+0163 
+0164 writtenTable = out;
+0165 <span class="keyword">end</span></pre></div>
 <hr><address>Generated by <strong><a href="http://www.artefact.tk/software/matlab/m2html/" title="Matlab Documentation in HTML">m2html</a></strong> &copy; 2005</address>
 </body>
 </html>

--- a/src/geckomat/gather_kcats/readDLKcatOutput.m
+++ b/src/geckomat/gather_kcats/readDLKcatOutput.m
@@ -6,10 +6,9 @@ function kcatList = readDLKcatOutput(model, outFile, modelAdapter)
 %
 % Input:
 %   model           an ecModel in GECKO 3 format (with ecModel.ec structure)
-%   outFile         name and path of the DLKcat output file. If nothing is
-%                   provided, an attempt will be made to read
-%                   data/DLKcat.tsv from the obj.params.path folder
-%                   specified in the modelAdapter.
+%   outFile         name and path of the DLKcat output file. (Optional,
+%                   default is data/DLKcat.tsv from the obj.params.path
+%                   folder specified in the modelAdapter)
 %   modelAdapter    a loaded model adapter (Optional, will otherwise use the
 %                   default model adapter).
 %

--- a/src/geckomat/gather_kcats/runDLKcat.m
+++ b/src/geckomat/gather_kcats/runDLKcat.m
@@ -1,4 +1,4 @@
-function runDLKcat(modelAdapter)
+function runDLKcat(modelAdapter,filePath)
 % runDLKcat
 %   Runs DLKcat to predict kcat values from a Docker image. Once DLKcat is succesfully
 %   run, the DLKcatFile will be overwritten with the DLKcat
@@ -8,6 +8,8 @@ function runDLKcat(modelAdapter)
 % Input
 %   modelAdapter    a loaded model adapter. (Optional, will otherwise use
 %                   the default model adapter)
+%   filePath        path to the DLKcat.tsv file. (Optional, will otherwise
+%                   assume data/DLKcat.tsv)
 %
 %   NOTE: 1. Requires Docker to be installed, and Docker Desktop running. Visit "https://www.docker.com"
 %         2. Runtime will depend on whether the image is to be downloaded or not.
@@ -18,11 +20,20 @@ if nargin < 1 || isempty(modelAdapter)
         error('Either send in a modelAdapter or set the default model adapter in the ModelAdapterManager.')
     end
 end
-
 params = modelAdapter.params;
 % Make sure path is full, not relative
 [~, params.path] = fileattrib(params.path);
 params.path=params.path.Name;
+
+if nargin < 2 || isempty(filePath)
+    filePath = fullfile(params.path,'data','DLKcat.tsv');
+elseif strcmp(filePath(end),{'\','/'})
+    filePath = fullfile(filePath,'DLKcat.tsv');
+end
+filePath = checkFileExistence(filePath,1);
+
+copyfile(filePath, fullfile(params.path,'data','tempDLKcat.tsv'));
+    
 
 %% Check and install requirements
 % On macOS, Docker might not be properly loaded if MATLAB is started via
@@ -38,11 +49,11 @@ if checks.docker.status ~= 0
 end
 
 disp('Running DLKcat prediction, this may take many minutes, especially the first time.')
-status = system(['docker run --rm -v "' fullfile(params.path,'/data') '":/data ghcr.io/sysbiochalmers/dlkcat-gecko:0.1 /bin/bash -c "python DLKcat.py /data/DLKcat.tsv /data/DLKcatOutput.tsv"']);
+status = system(['docker run --rm -v "' fullfile(params.path,'/data') '":/data ghcr.io/sysbiochalmers/dlkcat-gecko:0.1 /bin/bash -c "python DLKcat.py /data/tempDLKcat.tsv /data/tempDLKcatOutput.tsv"']);
+delete(fullfile(params.path,'/data/tempDLKcat.tsv'));
 
-if status == 0 && exist(fullfile(params.path,'data/DLKcatOutput.tsv'))
-    delete(fullfile(params.path,'/data/DLKcat.tsv'));
-    movefile(fullfile(params.path,'/data/DLKcatOutput.tsv'), fullfile(params.path,'/data/DLKcat.tsv'));
+if status == 0 && exist(fullfile(params.path,'data/tempDLKcatOutput.tsv'))
+    movefile(fullfile(params.path,'/data/tempDLKcatOutput.tsv'), filePath);
     disp('DKLcat prediction completed.');
 else    
     error('DLKcat encountered an error or it did not create any output file.')

--- a/src/geckomat/gather_kcats/writeDLKcatInput.m
+++ b/src/geckomat/gather_kcats/writeDLKcatInput.m
@@ -13,8 +13,9 @@ function writtenTable = writeDLKcatInput(model, ecRxns, modelAdapter, onlyWithSm
 %                   default model adapter).
 %   onlyWithSmiles  logical whether to only include metabolites with SMILES
 %                   (optional, default true)
-%   filename        Filename (Optional). Normally this parameter should not be 
-%                   supplied, but it is useful for test cases.
+%   filename        path to the input file, including the filename and .tsv
+%                   extension (Optional, default is data/DLKcat.tsv from
+%                   the obj.params.path folder specified in the modelAdapter)
 %   overwrite       logical whether existing file should be overwritten.
 %                   (Optional, default false, to prevent overwriting file
 %                   that already contains DLKcat-predicted kcat values).
@@ -50,6 +51,8 @@ end
 
 if nargin<5 || isempty(filename)
     filename = fullfile(params.path,'data','DLKcat.tsv');
+elseif ~endsWith(filename,'.tsv')
+    error('If filename is provided, it should include the .tsv extension.')
 end
 
 if nargin<6 || isempty(overwrite) || ~overwrite % If is true


### PR DESCRIPTION
### Main improvements in this PR:
- Features:
  - `runDLKcat` support alternative paths and names of the `DLKcat.tsv` file. (solves #392)

#### Instructions on merging this PR:
<!-- Chose ONE of the following two options
and replace [ ] with [X] to check the box.-->
- [x] This PR has `develop` as target branch, and will be resolved with a *squash-merge*.
- [ ] This PR has `main` as target branch, and will be resolved with a *merge commit*.
