### PR TITLE
CI: bump actions/checkout to v5 (Node 24)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: Fetch GECKO
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Fetch RAVEN
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: "SysBioChalmers/RAVEN"
           path: "RAVEN"


### PR DESCRIPTION
`actions/checkout@v4` runs on the deprecated Node.js 20 runtime (GitHub forces Node.js 24 from 2026-06-16; Node.js 20 removed 2026-09-16). Bump both checkout steps in `tests.yml` to `actions/checkout@v5` (Node.js 24) to clear the deprecation warning.