### PR TITLE
Fix a bug where DLKcat cannot write its own results

### DIFF
--- a/src/geckomat/gather_kcats/runDLKcat.m
+++ b/src/geckomat/gather_kcats/runDLKcat.m
@@ -53,7 +53,7 @@ status = system(['docker run --rm -v "' fullfile(params.path,'/data') '":/data g
 delete(fullfile(params.path,'/data/tempDLKcat.tsv'));
 
 if status == 0 && exist(fullfile(params.path,'data/tempDLKcatOutput.tsv'))
-    movefile(fullfile(params.path,'/data/tempDLKcatOutput.tsv'), filePath);
+    movefile(fullfile(params.path,'/data/tempDLKcatOutput.tsv'), filePath, 'f');
     disp('DKLcat prediction completed.');
 else    
     error('DLKcat encountered an error or it did not create any output file.')


### PR DESCRIPTION
The bug surfaces rarely but does occur and the fix should not impact the behavior negatively.

### Main improvements in this PR:
- Fixes:
  - `src/geckomat/gather_kcats/runDLKcat.m` sometimes failed to write the DLKcat output because the option to overwrite the input file is not specified.

#### Instructions on merging this PR:
- [ ] This PR has `develop` as target branch, and will be resolved with a *squash-merge*.
- [x] This PR has `main` as target branch, and will be resolved with a *merge commit*.
