### PR TITLE
Forward direction for protein usage and pool reactions

### DIFF
--- a/src/geckomat/change_model/makeEcModel.m
+++ b/src/geckomat/change_model/makeEcModel.m
@@ -377,10 +377,10 @@ if ~geckoLight
     usageRxns.stoichCoeffs    = cell(rxnNum,1);
     for i=1:numel(usageRxns.mets)
         usageRxns.mets{i}         = {proteinMets.mets{i}, 'prot_pool'};
-        usageRxns.stoichCoeffs{i} = [-1,1];
+        usageRxns.stoichCoeffs{i} = [1,-1];
     end
-    usageRxns.lb              = zeros(rxnNum,1) - 1000;
-    usageRxns.ub              = zeros(rxnNum,1);
+    usageRxns.lb              = zeros(rxnNum,1);
+    usageRxns.ub              = zeros(rxnNum,1) + 1000;
     usageRxns.rev             = ones(rxnNum,1);
     usageRxns.grRules         = ec.genes(uniprotSortId);
     if isfield(model,'subSystems')
@@ -389,13 +389,13 @@ if ~geckoLight
     model = addRxns(model,usageRxns);
 end
 
-%12: Add protein pool reaction (with open UB)
+%12: Add protein pool reaction (forward: -> prot_pool; UB set by setProtPoolSize)
 poolRxn.rxns            = 'prot_pool_exchange';
 poolRxn.rxnNames        = poolRxn.rxns;
 poolRxn.mets            = {'prot_pool'};
-poolRxn.stoichCoeffs    = {-1};
-poolRxn.lb              = -1000;
-poolRxn.ub              = 0;
+poolRxn.stoichCoeffs    = {1};
+poolRxn.lb              = 0;
+poolRxn.ub              = 1000;
 poolRxn.rev             = 1;
 if isfield(model,'subSystems')
     poolRxn.subSystems  = 'Protein usage';

--- a/src/geckomat/change_model/setProtPoolSize.m
+++ b/src/geckomat/change_model/setProtPoolSize.m
@@ -65,6 +65,6 @@ if isempty(Ptot)
     Ptot = modelAdapter.getParameters().Ptot;
 end
 
-model.lb(strcmp(model.rxns, 'prot_pool_exchange')) = -(Ptot*f*sigma*1000);
+model.ub(strcmp(model.rxns, 'prot_pool_exchange')) = Ptot*f*sigma*1000;
 end
 

--- a/src/geckomat/gather_kcats/getStandardKcat.m
+++ b/src/geckomat/gather_kcats/getStandardKcat.m
@@ -223,9 +223,9 @@ if ~any(strcmp(model.mets,'prot_standard'))
         proteinStdUsageRxn.rxns         = {'usage_prot_standard'};
         proteinStdUsageRxn.rxnNames     = proteinStdUsageRxn.rxns;
         proteinStdUsageRxn.mets         = {proteinStdMets.mets, 'prot_pool'};
-        proteinStdUsageRxn.stoichCoeffs = [-1, 1];
-        proteinStdUsageRxn.lb           = -1000;
-        proteinStdUsageRxn.ub           = 0;
+        proteinStdUsageRxn.stoichCoeffs = [1, -1];
+        proteinStdUsageRxn.lb           = 0;
+        proteinStdUsageRxn.ub           = 1000;
         proteinStdUsageRxn.grRules      = proteinStdGenes.genes;
 
         model = addRxns(model, proteinStdUsageRxn);

--- a/src/geckomat/kcat_sensitivity_analysis/sensitivityTuning.m
+++ b/src/geckomat/kcat_sensitivity_analysis/sensitivityTuning.m
@@ -110,9 +110,9 @@ if ~m.ec.geckoLight
         drawFluxes(drawRxns) = res.x(drawRxns);
         % Remove from the list user defined proteins
         drawFluxes(idxToIgnore) = 0;
-        [~,sel]              = min(drawFluxes); % since bounds -1000 to 0
+        [~,sel]              = max(drawFluxes); % since bounds 0 to 1000
         %Now get the metabolite
-        metSel               = m.S(:,sel) < 0; % negative coeff
+        metSel               = m.S(:,sel) > 0; % positive coeff (forward usage)
         %now find the reaction with the largest consumption of this protein
         protFluxes           = m.S(metSel,:).' .* res.x; %negative
         [~,rxnSel]           = min(protFluxes);

--- a/src/geckomat/limit_proteins/constrainEnzConcs.m
+++ b/src/geckomat/limit_proteins/constrainEnzConcs.m
@@ -65,13 +65,14 @@ else
     protCons = ~isnan(model.ec.concs);
 end
 
-%Set all reactions to draw from prot_pool
-model.S(protPoolIdx, usageRxnsIdx) = 1;
-model.lb(usageRxnsIdx) = -1000;
+%Set all reactions to draw from prot_pool (forward: prot_pool -> prot_<id>)
+model.S(protPoolIdx, usageRxnsIdx) = -1;
+model.lb(usageRxnsIdx) = 0;
+model.ub(usageRxnsIdx) = 1000;
 
 %If non-NaN in model.ec.concs, then constrain by UB
 if any(protCons)
 %    model.S(protPoolIdx, usageRxnsIdx(protCons)) = 0; % Since GECKO 3.2.0
-    model.lb(usageRxnsIdx(protCons)) = -model.ec.concs(protCons);
+    model.ub(usageRxnsIdx(protCons)) = model.ec.concs(protCons);
 end
 end

--- a/src/geckomat/limit_proteins/flexibilizeEnzConcs.m
+++ b/src/geckomat/limit_proteins/flexibilizeEnzConcs.m
@@ -9,7 +9,7 @@ function [model, flexEnz] = flexibilizeEnzConcs(model, varargin)
 % protein pool exchange that is limiting growth. In that case, an attempt
 % will be made to relax the protein pool exchange reaction, and if the growth
 % rate indeed increases, it is suggested to set the protein pool exchange
-% unconstrained (lb=-1000) before again running flexibilizeEnzConcs. Such
+% unconstrained (ub=1000) before again running flexibilizeEnzConcs. Such
 % situations, where a proteomics integrated ecModel is overconstrained, may
 % occur if the ecModel should be able to simulate maximum growth rate (from
 % e.g. batch cultivation).
@@ -160,7 +160,7 @@ if any(protConcs)
                 protUsageIdx = strcmpi(model.rxns, strcat('usage_prot_', proteins(maxIdx)));
 
                 % replace the UB
-                model.lb(protUsageIdx) = -(model.ec.concs(protConcs(maxIdx)) * (1+increase));
+                model.ub(protUsageIdx) = model.ec.concs(protConcs(maxIdx)) * (1+increase);
 
                 % Get the new growth rate
                 sol = solveLP(model,0,[],hs);
@@ -177,22 +177,23 @@ if any(protConcs)
         else
             disp('No (more) limiting enzymes have been found. Attempting to increase protein pool exchange...')
             protPoolIdx = getIndexes(model,'prot_pool_exchange','rxns');
-            oldProtPool = -model.lb(protPoolIdx);
-            tempModel = setParam(model,'lb',protPoolIdx,-1000);
+            oldProtPool = model.ub(protPoolIdx);
+            tempModel = setParam(model,'ub',protPoolIdx,1000);
             tempModel = setParam(tempModel,'ub',bioRxnIdx,expGrowth);
             sol = solveLP(tempModel);
             if (sol.f-predGrowth)>1e-3 % There is improvement in growth rate
                 % Find new protein pool constraint
                 predGrowth = sol.f;
                 tempModel = setParam(tempModel,'lb',bioRxnIdx,predGrowth);
-                tempModel = setParam(tempModel,'obj',protPoolIdx,1);
+                % minimise pool usage (solveLP maximises the objective, so use -1)
+                tempModel = setParam(tempModel,'obj',protPoolIdx,-1);
                 sol = solveLP(tempModel);
-                newProtPool = sol.f;
-                model.lb(protPoolIdx) = newProtPool;
-                fprintf(['Changing the lower bound of protein pool exchange from %s ',...
+                newProtPool = sol.x(protPoolIdx);
+                model.ub(protPoolIdx) = newProtPool;
+                fprintf(['Changing the upper bound of protein pool exchange from %s ',...
                          'to %s enabled a\ngrowth rate of %s. It can be helpful to set ', ...
-                         'the lower bound of protein\npool exchange to -1000 before ',...
-                         'running flexibilizeEnzConcs.\n'],num2str(-oldProtPool), ...
+                         'the upper bound of protein\npool exchange to 1000 before ',...
+                         'running flexibilizeEnzConcs.\n'],num2str(oldProtPool), ...
                          num2str(newProtPool),num2str(predGrowth));
                 changedProtPool = true;
             else
@@ -220,14 +221,15 @@ if flexBreak == false && ~isempty(protFlex)
     % Not all flexibilized proteins require flexibilization in the end
     % Test flux distribution with minimum prot_pool usage
     modelTemp       = setParam(model,'var',params.bioRxn,expGrowth,0.5);
-    modelTemp       = setParam(modelTemp,'obj','prot_pool_exchange',1);
+    % minimise pool usage (solveLP maximises the objective, so use -1)
+    modelTemp       = setParam(modelTemp,'obj','prot_pool_exchange',-1);
     sol             = solveLP(modelTemp,1);
     % Check which concentrations can remain unchanged
     newConcs        = abs(sol.x(protUsageIdx));
     keepOld         = newConcs<oldConcs;
     % Set UBs
-    model.lb(protUsageIdx(keepOld))  = -oldConcs(keepOld);
-    model.lb(protUsageIdx(~keepOld)) = -newConcs(~keepOld);
+    model.ub(protUsageIdx(keepOld))  = oldConcs(keepOld);
+    model.ub(protUsageIdx(~keepOld)) = newConcs(~keepOld);
     % Output structure
     protFlex(keepOld) = [];
     oldConcs(keepOld) = [];
@@ -245,7 +247,7 @@ else
 
     flexEnz.uniprotIDs = protFlex;
     flexEnz.oldConcs   = model.ec.concs(ecProtId);
-    flexEnz.flexConcs  = abs(model.lb(protUsageIdx));
+    flexEnz.flexConcs  = model.ub(protUsageIdx);
     flexEnz.frequence  = frequence(frequence>0);
 end
 if changedProtPool

--- a/src/geckomat/limit_proteins/getConcControlCoeffs.m
+++ b/src/geckomat/limit_proteins/getConcControlCoeffs.m
@@ -72,7 +72,7 @@ protUsageRxns = strcat('usage_prot_', model.ec.enzymes(protIdx));
 
 for i = 1:numel(proteins)
     % Get the previous concentration
-    prevConc = model.lb(protUsageRxnIdx(i));
+    prevConc = model.ub(protUsageRxnIdx(i));
 
     % Only consider those with a usage close the UB
     if (sol.x(protUsageRxnIdx(i))/prevConc) > limit
@@ -85,7 +85,7 @@ for i = 1:numel(proteins)
         tempModel = model;
         % Increase the concentration by flexfactor
         newConc = prevConc*(foldChange);
-        tempModel.lb(protUsageRxnIdx(i)) = newConc;
+        tempModel.ub(protUsageRxnIdx(i)) = newConc;
 
         % Get the new growth rate after the adjustment
         [tempSol,hs] = solveLP(tempModel,0,[],hs);
@@ -94,7 +94,7 @@ for i = 1:numel(proteins)
         % Calculate the coeff only if new growth rate is significantly
         % higher than initial value
         if (tempGrowth-initialGrowth)>1e-10
-            controlCoeffs(i) = (tempGrowth-initialGrowth)/(prevConc-newConc);
+            controlCoeffs(i) = (tempGrowth-initialGrowth)/(newConc-prevConc);
         end
     end
 

--- a/src/geckomat/limit_proteins/updateProtPool.m
+++ b/src/geckomat/limit_proteins/updateProtPool.m
@@ -52,7 +52,7 @@ modelAdapter = p.modelAdapter;
 protRxns = find(startsWith(ecModel.rxns,'usage_prot_'));
 poolMetIdx = find(strcmp(ecModel.mets,'prot_pool'));
 % Selected proteins with proteomics constraints
-constProtRxns = ~(ecModel.lb(protRxns)==-1000);
+constProtRxns = ~(ecModel.ub(protRxns)==1000);
 % Are any still drawing from prot_pool? This is introduced in GECKO 3.2.0.
 if any(full(ecModel.S(poolMetIdx,protRxns(constProtRxns))))
     error(['In the provided ecModel, all protein usage reactions, both with ' ...
@@ -91,7 +91,7 @@ Pnew = (Ptot - Pmeas) * params.f;
 
 if Pnew > 0
     PoolRxnIdx = strcmp(ecModel.rxns,'prot_pool_exchange');
-    ecModel.lb(PoolRxnIdx) = -Pnew*params.sigma;
+    ecModel.ub(PoolRxnIdx) = Pnew*params.sigma;
     sol = solveLP(ecModel);
     if isempty(sol.x)
         error(['Estimating the remaining protein pool by subtracting the ' ...

--- a/src/geckomat/utilities/addNewRxnsToEC.m
+++ b/src/geckomat/utilities/addNewRxnsToEC.m
@@ -202,10 +202,10 @@ else
     usageRxns.stoichCoeffs    = cell(numel(usageRxns.rxns),1);
     for i=1:numel(usageRxns.mets)
         usageRxns.mets{i}         = {proteinMets.mets{i}, 'prot_pool'};
-        usageRxns.stoichCoeffs{i} = [-1,1];
+        usageRxns.stoichCoeffs{i} = [1,-1];
     end
-    usageRxns.lb              = zeros(numel(usageRxns.rxns),1) - 1000;
-    usageRxns.ub              = zeros(numel(usageRxns.rxns),1);
+    usageRxns.lb              = zeros(numel(usageRxns.rxns),1);
+    usageRxns.ub              = zeros(numel(usageRxns.rxns),1) + 1000;
     usageRxns.rev             = ones(numel(usageRxns.rxns),1);
     usageRxns.grRules         = newEnzymes.genes;
     model = addRxns(model,usageRxns);

--- a/src/geckomat/utilities/enzymeUsage.m
+++ b/src/geckomat/utilities/enzymeUsage.m
@@ -62,16 +62,16 @@ end
 usageData.protID      = ecModel.ec.enzymes;
 [~,rxnIdx] = ismember(strcat('usage_prot_',ecModel.ec.enzymes),ecModel.rxns);
 
-usageData.LB          = ecModel.lb(rxnIdx);
+usageData.UB          = ecModel.ub(rxnIdx);
 usageData.absUsage    = abs(fluxes(rxnIdx));
-usageData.capUsage    = abs(usageData.absUsage./usageData.LB);
+usageData.capUsage    = abs(usageData.absUsage./usageData.UB);
 usageData.fluxes      = fluxes;
 
 if ~zero
-    nonzero               = usageData.absUsage<0;
+    nonzero               = usageData.absUsage>0;
     usageData.absUsage    = usageData.absUsage(nonzero);
     usageData.capUsage    = usageData.capUsage(nonzero);
-    usageData.LB          = usageData.LB(nonzero);
+    usageData.UB          = usageData.UB(nonzero);
     usageData.protID      = usageData.protID(nonzero);
 end
 end

--- a/src/geckomat/utilities/getSubsetEcModel.m
+++ b/src/geckomat/utilities/getSubsetEcModel.m
@@ -39,7 +39,7 @@ if numel(rxnsDiff) > 0
 end
 
 % Check if original bigEcModel contains context-dependent protein constraints
-if any(bigEcModel.lb(startsWith(bigEcModel.rxns,'usage_prot_')) ~= -1000)
+if any(bigEcModel.ub(startsWith(bigEcModel.rxns,'usage_prot_')) ~= 1000)
     printOrange(['WARNING: The bigEcModel is constraint by protein concentrations that are\n' ...
                  'likely not relevant in the constructed smallEcModel.\n']);
 end

--- a/src/geckomat/utilities/reportEnzymeUsage.m
+++ b/src/geckomat/utilities/reportEnzymeUsage.m
@@ -126,7 +126,7 @@ topUsage.rxnID      = {};
 topUsage.rxnNames   = {};
 topUsage.grRules    = {};
 
-protPool = -ecModel.lb(strcmp(ecModel.rxns,'prot_pool_exchange'));
+protPool = ecModel.ub(strcmp(ecModel.rxns,'prot_pool_exchange'));
 
 for i=1:numel(topEnzyme)
     [rxns, kcat, idx, rxnNames, grRules] = getReactionsFromEnzyme(ecModel,topEnzyme{i});

--- a/test/unit_tests/geckoCoreFunctionTests.m
+++ b/test/unit_tests/geckoCoreFunctionTests.m
@@ -72,8 +72,8 @@ function testmakeEcModelLightModel_tc0002(testCase)
     %check mets
     expMetNames = [model.metNames;'prot_pool'];
     verifyEqual(testCase,ecModel.metNames,expMetNames)
-    %check S matrix
-    expS = [model.S model.S(:,2:3)*-1 sparse(length(model.mets),1);sparse(1,length(ecModel.rxns)-1) -1];
+    %check S matrix (forward prot_pool_exchange: -> prot_pool, coeff +1)
+    expS = [model.S model.S(:,2:3)*-1 sparse(length(model.mets),1);sparse(1,length(ecModel.rxns)-1) 1];
     verifyEqual(testCase,ecModel.S,expS)
     
     %2) Check the ec structure
@@ -144,16 +144,16 @@ function testsetProtPoolSize_tc0005(testCase)
     model = getGeckoTestModel();
     ecModel = makeEcModel(model, false, adapter);
     ecModel = setProtPoolSize(ecModel, [], [], [], adapter);
-    verifyEqual(testCase,ecModel.lb(length(ecModel.rxns)),-1000)
+    verifyEqual(testCase,ecModel.ub(length(ecModel.rxns)),1000)
     ecModel = setProtPoolSize(ecModel, 1, 5, 1);
-    verifyEqual(testCase,ecModel.lb(length(ecModel.rxns)),-5000)
+    verifyEqual(testCase,ecModel.ub(length(ecModel.rxns)),5000)
 
     %light
     ecModel = makeEcModel(model, true, adapter);
     ecModel = setProtPoolSize(ecModel, [], [], [], adapter);
-    verifyEqual(testCase,ecModel.lb(length(ecModel.rxns)),-1000)
+    verifyEqual(testCase,ecModel.ub(length(ecModel.rxns)),1000)
     ecModel = setProtPoolSize(ecModel, 1, 5, 1);
-    verifyEqual(testCase,ecModel.lb(length(ecModel.rxns)),-5000)
+    verifyEqual(testCase,ecModel.ub(length(ecModel.rxns)),5000)
 end
 
 %For both full and light

--- a/test/unit_tests/getBaseExpTstEcModelProperties.m
+++ b/test/unit_tests/getBaseExpTstEcModelProperties.m
@@ -24,16 +24,16 @@ function [expRxns, expMetNames, expS] = getBaseExpTstEcModelProperties()
     expS(2,9) = 1;
     expS(1,10) = -1;%E1
     expS(2,11) = -1;%E2
-    %Now add the protein reactions
-    expS(10,12) = 1;%P1
-    expS(5,12) = -1;
-    expS(10,13) = 1;%P2
-    expS(6,13) = -1;
-    expS(10,14) = 1;%P3
-    expS(7,14) = -1;
-    expS(10,15) = 1;%P4
-    expS(8,15) = -1;
-    expS(10,16) = 1;%P5
-    expS(9,16) = -1;
-    expS(10,17) = -1;%prot pool
+    %Now add the protein reactions (forward: prot_pool -> prot_<id>)
+    expS(10,12) = -1;%P1
+    expS(5,12) = 1;
+    expS(10,13) = -1;%P2
+    expS(6,13) = 1;
+    expS(10,14) = -1;%P3
+    expS(7,14) = 1;
+    expS(10,15) = -1;%P4
+    expS(8,15) = 1;
+    expS(10,16) = -1;%P5
+    expS(9,16) = 1;
+    expS(10,17) = 1;%prot pool
 end


### PR DESCRIPTION
## Description

Switches the protein enzyme-usage reactions (`usage_prot_<id>`) and the protein pool exchange (`prot_pool_exchange`) to the **forward (positive-flux)** direction, matching the geckopy / cobrapy convention. GECKO 3 defined them in the reverse (negative-flux) direction.

**New convention:**
- `usage_prot_<id>`: `prot_pool -> prot_<id>`, bounds `[0, 1000]` — enzyme abundance `[E] = +flux` (was `-flux`)
- `prot_pool_exchange`: `-> prot_pool`; `setProtPoolSize` now sets the **upper** bound to the pool budget

The metabolic enzyme stoichiometric coefficient is unchanged (`-MW*subunits/(kcat*3600)`, negative in both conventions), so `applyKcatConstraints` is untouched.

## Changes

- **Reaction definitions / bounds:** `makeEcModel`, `addNewRxnsToEC`, `getStandardKcat`, `setProtPoolSize`
- **Proteomics constraints:** `constrainEnzConcs`, `flexibilizeEnzConcs`, `updateProtPool`, `getConcControlCoeffs`, `getSubsetEcModel` (`lb <-> ub`, `-conc -> +conc`; `flexibilizeEnzConcs` minimises the pool with `obj=-1` since `solveLP` maximises)
- **Usage readouts:** `enzymeUsage`, `reportEnzymeUsage`, `sensitivityTuning` (read usage as `+flux`)
- **Unit tests:** updated expected S-matrices (full + light) and pool bounds

## Validation

- `geckoCoreFunctionTests`: same pass/fail as the clean baseline (only the network/offline-dependent tests fail) — no regressions.
- Functional check on a built test ecModel: positive growth, non-negative usage and pool fluxes, and growth scaling with the protein pool (the pool binds).