### PR TITLE
Fix movefile overwrite flag in runDLKcat

### DIFF
--- a/src/geckomat/gather_kcats/runDLKcat.m
+++ b/src/geckomat/gather_kcats/runDLKcat.m
@@ -53,7 +53,7 @@ status = system(['docker run --rm -v "' fullfile(params.path,'/data') '":/data g
 delete(fullfile(params.path,'/data/tempDLKcat.tsv'));
 
 if status == 0 && exist(fullfile(params.path,'data/tempDLKcatOutput.tsv'))
-    movefile(fullfile(params.path,'/data/tempDLKcatOutput.tsv'), filePath);
+    movefile(fullfile(params.path,'/data/tempDLKcatOutput.tsv'), filePath, 'f');
     disp('DKLcat prediction completed.');
 else    
     error('DLKcat encountered an error or it did not create any output file.')


### PR DESCRIPTION
Closes #418.

### Change

Adds the `'f'` (force) flag to `movefile` in `runDLKcat.m` so the output file is overwritten when it already exists at the destination path. Without it, a pre-existing `tempDLKcatOutput.tsv` causes `movefile` to error and DLKcat results are lost.

### Notes

- Original fix proposed by @emilpaulitz in #418, which was opened against `main`. This PR lands the same change on `develop` per the contribution workflow.
- No behaviour change when the destination file does not already exist.

#### Instructions on merging this PR:
- [x] This PR has `develop` as target branch, and will be resolved with a *squash-merge*.
- [ ] This PR has `main` as target branch, and will be resolved with a *merge commit*.