### PR TITLE
Fix: KEGG parsing whitespace bug and infinite retry on download failure

### DIFF
--- a/src/geckomat/get_enzyme_data/loadDatabases.m
+++ b/src/geckomat/get_enzyme_data/loadDatabases.m
@@ -146,13 +146,22 @@ for i = 1:queries
     end
     url      = ['http://rest.kegg.jp/get/' keggID ':' strjoin([gene_id{firstIdx:lastIdx}],['+' keggID ':'])];
 
-    retry = true;
-    while retry
+    maxRetries = 5;
+    attempt    = 0;
+    success    = false;
+    while ~success
+        attempt = attempt + 1;
         try
-            retry = false;
-            out   = webread(url,webOptions);
-        catch
-            retry = true;
+            out     = webread(url,webOptions);
+            success = true;
+        catch ME
+            if attempt >= maxRetries
+                error(['Unable to download KEGG data after %d attempts.\n' ...
+                       'URL: %s\n' ...
+                       'Check your internet connection or KEGG status, and try again.\n' ...
+                       'Original error: %s'], maxRetries, url, ME.message);
+            end
+            pause(2); % wait before retry
         end
     end
     outSplit = strsplit(out,['///' 10]); %10 is new line character

--- a/src/geckomat/get_enzyme_data/loadDatabases.m
+++ b/src/geckomat/get_enzyme_data/loadDatabases.m
@@ -164,6 +164,13 @@ for i = 1:queries
 end
 
 %% Parsing of info to keggDB format
+
+% Remove leading/trailing whitespace (KEGG entries can have a stray
+% newline before ENTRY after the '///' split), otherwise downstream
+% startsWith(...,'ENTRY ') checks fail to filter genes without
+% AASEQ/UniProt fields
+keggData = strtrim(keggData);
+
 sequence  = regexprep(keggData,'.*AASEQ\s+\d+\s+([A-Z\s])+?\s+NTSEQ.*','$1');
 %No AASEQ -> no protein -> not of interest
 noProt    = startsWith(sequence,'ENTRY ');

--- a/src/geckomat/get_enzyme_data/loadDatabases.m
+++ b/src/geckomat/get_enzyme_data/loadDatabases.m
@@ -188,7 +188,7 @@ noUni     = startsWith(uni,'ENTRY ');
 uni(noProt | noUni)       = [];
 keggData(noProt | noUni) = [];
 sequence(noProt | noUni)  = [];
-sequence  = regexprep(sequence,'\s*','');
+sequence = regexprep(sequence,'\s+','');
 keggGene  = regexprep(keggData,'ENTRY\s+(\S+?)\s.+','$1');
 
 switch keggGeneID


### PR DESCRIPTION
### Main improvements in this PR:

While working with *Escherichia coli*, the downloaded `kegg.tsv` file had errors and did not keep the expected structure due to a stray leading newline in the KEGG entries after parsing. This PR fixes that issue, along with a couple of related improvements found while investigating it.

- Fixes:
  - `downloadKEGG` left a stray leading newline in `keggData` entries after
    splitting on `///`, which broke the `startsWith(...,'ENTRY ')` checks used
    to filter out genes without AASEQ or UniProt fields, letting invalid
    entries slip into the final KEGG database table
  - `downloadKEGG` retry loop for `webread` had no attempt limit, causing the
    function to hang indefinitely if KEGG was down or the URL was invalid,
    with the original error silently discarded
- Performance:
  - `downloadKEGG` used `\s*` instead of `\s+` when stripping whitespace from
    protein sequences, causing unnecessary zero-length matches at every
    position in the string

#### Instructions on merging this PR:
- [X] This PR has `develop` as target branch, and will be resolved with a *squash-merge*.
- [ ] This PR has `main` as target branch, and will be resolved with a *merge commit*.