### PR TITLE
Fix: KEGG entry parsing and bounded download retries

### DIFF
--- a/src/geckomat/get_enzyme_data/loadDatabases.m
+++ b/src/geckomat/get_enzyme_data/loadDatabases.m
@@ -161,13 +161,24 @@ for i = 1:queries
     end
     url      = ['http://rest.kegg.jp/get/' keggID ':' strjoin([gene_id{firstIdx:lastIdx}],['+' keggID ':'])];
 
-    retry = true;
-    while retry
+    % KEGG may be temporarily unresponsive, retry with exponential backoff
+    maxRetries = 5;
+    for attempt = 1:maxRetries
         try
-            retry = false;
-            out   = webread(url,webOptions);
-        catch
-            retry = true;
+            out = webread(url,webOptions);
+            break
+        catch ME
+            % A malformed or non-existing query will not succeed on retry
+            noRetry = ismember(ME.identifier,{'MATLAB:webservices:HTTP400StatusCodeError', ...
+                                              'MATLAB:webservices:HTTP404StatusCodeError'});
+            if noRetry || attempt == maxRetries
+                error(['Unable to download KEGG data (attempt %d of %d).\n' ...
+                       'URL: %s\n' ...
+                       'Check your internet connection and the status of the KEGG ' ...
+                       'REST API, then try again.\nOriginal error: %s'], ...
+                       attempt, maxRetries, url, ME.message);
+            end
+            pause(min(2^attempt,30)) % Wait 2, 4, 8 and 16 seconds before retrying
         end
     end
     outSplit = strsplit(out,['///' 10]); %10 is new line character
@@ -179,6 +190,12 @@ for i = 1:queries
 end
 
 %% Parsing of info to keggDB format
+% Entries returned by KEGG are separated by '///' followed by an empty line,
+% leaving a stray newline at the start of each entry after splitting. This
+% would break the startsWith(...,'ENTRY ') checks below, which detect entries
+% where the regular expression did not match and returned the entry unchanged
+keggData  = strtrim(keggData);
+
 sequence  = regexprep(keggData,'.*AASEQ\s+\d+\s+([A-Z\s])+?\s+NTSEQ.*','$1');
 %No AASEQ -> no protein -> not of interest
 noProt    = startsWith(sequence,'ENTRY ');
@@ -187,7 +204,7 @@ noUni     = startsWith(uni,'ENTRY ');
 uni(noProt | noUni)       = [];
 keggData(noProt | noUni) = [];
 sequence(noProt | noUni)  = [];
-sequence  = regexprep(sequence,'\s*','');
+sequence  = regexprep(sequence,'\s+','');
 keggGene  = regexprep(keggData,'ENTRY\s+(\S+?)\s.+','$1');
 
 switch keggGeneID


### PR DESCRIPTION
### Main improvements in this PR:

Ports the fix from #422 to `develop4`, where `downloadKEGG` is still unchanged (`develop4` does not contain the tip of `develop`), with a different retry implementation.

- Fixes:
  - `loadDatabases`/`downloadKEGG` left a stray leading newline on every entry
    except the first after splitting the KEGG response on `///`, because KEGG
    follows each `///` separator with an empty line. The
    `startsWith(...,'ENTRY ')` checks that detect a non-matching `regexprep`
    therefore never fired, so genes without AASEQ or UniProt fields were not
    filtered out, and entries without an EC number or pathway had their full
    multi-line text written into those columns, breaking the structure of
    `kegg.tsv`. Entries are now trimmed after splitting.
  - `loadDatabases`/`downloadKEGG` retried `webread` indefinitely, hanging if
    KEGG was unresponsive or the URL invalid, and discarded the original error.
    Retries are now bounded to five attempts with exponential backoff (2, 4, 8
    and 16 seconds), fail immediately on HTTP 400 and 404 since a malformed
    query will not succeed on retry, and report the original error message.
- Performance:
  - `loadDatabases`/`downloadKEGG` used `\s*` instead of `\s+` when stripping
    whitespace from protein sequences, causing zero-length matches at every
    position in the string.

Verified against a live KEGG response mixing coding and non-coding genes
(`eco:b0001+b4413+b0002+b4762+b0003`): before the fix all five entries passed
the filters and the two ncRNA entries polluted the gene, UniProt and EC
columns; after the fix only the three protein-coding entries are kept, with
correct sequences and EC numbers. Both retry exit paths were exercised against
a 404 URL (fails on the first attempt) and an unreachable host (fails after the
last attempt).

#### Instructions on merging this PR:
- [X] This PR has `develop` as target branch, and will be resolved with a *squash-merge*.
- [ ] This PR has `main` as target branch, and will be resolved with a *merge commit*.
