### PR TITLE
fix: port progressbar calls to RAVEN's progressReport

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,10 +20,15 @@ jobs:
       - name: Checkout GECKO
         uses: actions/checkout@v5
 
+      # develop3, not RAVEN's default branch. GECKO 4 is developed against
+      # RAVEN's develop3 line, and taking the default meant testing against
+      # main --- which is why the removal of progressbar went unnoticed here
+      # while breaking every user on develop3.
       - name: Checkout RAVEN
         uses: actions/checkout@v5
         with:
           repository: SysBioChalmers/RAVEN
+          ref: develop3
           path: RAVEN
 
       - name: Set up MATLAB

--- a/src/geckomat/change_model/applyComplexData.m
+++ b/src/geckomat/change_model/applyComplexData.m
@@ -107,8 +107,9 @@ end
 % Remove excess space
 complexMatrix(:,lastProt+1:end) = [];
 complexProts(lastProt+1:end) = [];
-progressbar('Assign complexes to reactions')
+PB = progressReport(numel(rxnNames), 'Assign complexes to reactions');
 for i = 1:numel(rxnNames)
+    PB.count;
     % Get the proteins from the model
     modelProts = model.ec.enzymes(find(model.ec.rxnEnzMat(i,:)));
     [protsInMat, protsIdx] = ismember(modelProts,complexProts);
@@ -180,9 +181,8 @@ for i = 1:numel(rxnNames)
             proposedComplex{proposedComplexCount,8} = percMatch(propComplex)*100;
         end
     end
-    progressbar(i/numel(rxnNames))    
 end
-progressbar(1) % Make sure it closes  
+PB.done;
 
 % Remove empty space
 foundComplex(foundComplexCount+1:end,:) = [];

--- a/src/geckomat/change_model/findMetSmiles.m
+++ b/src/geckomat/change_model/findMetSmiles.m
@@ -60,9 +60,10 @@ else
 end
 
 if any(~metMatch)
-    progressbar('Querying PubChem for SMILES by metabolite names')
+    PB = progressReport(numel(uniqueNames), 'Querying PubChem for SMILES by metabolite names');
     webOptions = weboptions('Timeout', 30);
     for i = 1:numel(uniqueNames)
+        PB.count;
         if metMatch(i)
             continue;
         end
@@ -101,8 +102,8 @@ if any(~metMatch)
         fID = fopen(smilesDBfile,'a');
         fprintf(fID,'%s\t%s\n',out{:});
         fclose(fID);
-        progressbar(i/numel(uniqueNames))
     end
+    PB.done;
     if verbose
         fprintf('Model-specific SMILES database stored at %s\n',smilesDBfile);
     end
@@ -119,5 +120,4 @@ else
     emptySmiles = cellfun(@isempty,model.metSmiles);
     model.metSmiles(emptySmiles) = newSmiles(emptySmiles);
 end
-progressbar(1) % Make sure it closes
 end

--- a/src/geckomat/change_model/getComplexData.m
+++ b/src/geckomat/change_model/getComplexData.m
@@ -86,9 +86,9 @@ if data.size == 0
 end
 complexData = cell(data.size,7);
 
-progressbar('Retrieving information for complexes');
+PB = progressReport(data.size, 'Retrieving information for complexes');
 for i = 1:data.size
-    progressbar(i/data.size) % Update progress bar
+    PB.count;
     url2 = 'https://www.ebi.ac.uk/intact/complex-ws/complex/';
     complexID = data.elements(i,1).complexAC;
     try

--- a/src/geckomat/gather_kcats/fuzzyKcatMatching.m
+++ b/src/geckomat/gather_kcats/fuzzyKcatMatching.m
@@ -183,9 +183,10 @@ if forceWClvl == 1
     eccodes = regexprep(eccodes,'.*','-\.-\.-\.-');
 end
 
-progressbar('Gathering kcat values by fuzzy matching to BRENDA database')
+PB = progressReport(mM, 'Gathering kcat values by fuzzy matching to BRENDA database');
 %Main loop:
 for i = 1:mM
+    PB.count;
     %Match:
     EC = eccodes{i};
     if ~isempty(EC)
@@ -197,7 +198,6 @@ for i = 1:mM
                 phylDistStruct,org_index,SAcell,ECIndexIds,EcIndexIndices);
         end
     end
-    progressbar(i/mM)
 end
 
 kcatList.source      = 'brenda';

--- a/src/geckomat/get_enzyme_data/getECfromDatabase.m
+++ b/src/geckomat/get_enzyme_data/getECfromDatabase.m
@@ -96,8 +96,9 @@ eccodes(:)= {''};
 conflicts = cell(1,4);
 
 rxnEnzMat = logical(rxnEnzMat);
-progressbar('Assigning EC numbers from database')
+PB = progressReport(n, 'Assigning EC numbers from database');
 for i = 1:n
+    PB.count;
     gns = genes(rxnEnzMat(i,:).');
     if ~isempty(gns)
         %Find match in Uniprot:
@@ -142,7 +143,6 @@ for i = 1:n
             %}
         end
     end
-    progressbar(i/n)
 end
 
 %Display error message with the multiple gene-protein matches found

--- a/src/geckomat/get_enzyme_data/loadDatabases.m
+++ b/src/geckomat/get_enzyme_data/loadDatabases.m
@@ -135,7 +135,6 @@ end
 
 function downloadKEGG(keggID, filePath, keggGeneID)
 %% Download gene information
-progressbar(['Downloading KEGG data for organism code ' keggID])
 webOptions = weboptions('Timeout',30);
 try
     gene_list = webread(['http://rest.kegg.jp/list/' keggID],webOptions);
@@ -152,7 +151,9 @@ gene_id   = regexpi(gene_list,['(?<=' keggID ':)\S+'],'match');
 genesPerQuery = 10;
 queries = ceil(numel(gene_id)/genesPerQuery);
 keggData  = cell(numel(gene_id),1);
+PB = progressReport(queries, ['Downloading KEGG data for organism code ' keggID]);
 for i = 1:queries
+    PB.count;
     % Download batches of genes
     firstIdx = i*genesPerQuery-(genesPerQuery-1);
     lastIdx  = i*genesPerQuery;
@@ -175,7 +176,6 @@ for i = 1:queries
         error('KEGG returns less genes per query') %Reduce genesPerQuery
     end
     keggData(firstIdx:lastIdx) = outSplit(1:end-1);
-    progressbar(i/queries)
 end
 
 %% Parsing of info to keggDB format

--- a/src/geckomat/utilities/ecFSEOF.m
+++ b/src/geckomat/utilities/ecFSEOF.m
@@ -108,8 +108,9 @@ alpha    = iniTarget:((maxTarget-iniTarget)/(nSteps-1)):maxTarget;
 v_matrix = zeros(length(model.rxns),length(alpha));
 
 % Enforce objective flux iteratively
-progressbar('Flux Scanning with Enforced Objective Function')
+PB = progressReport(nSteps, 'Flux Scanning with Enforced Objective Function');
 for i = 1:nSteps
+    PB.count;
     % Enforce the objetive flux of product formation
     model = setParam(model,'eq',prodTargetRxnIdx,alpha(i));
 
@@ -121,9 +122,8 @@ for i = 1:nSteps
     % Store flux distribution
     v_matrix(:,i) = sol.x;
 
-    progressbar(i/nSteps)
 end
-progressbar(1) % Make sure it closes
+PB.done;
 
 % Take out rxns with no grRule and standard gene
 withGR         = ~cellfun(@isempty,model.grRules);
@@ -201,8 +201,9 @@ target_type_genes = cell(size(genes));
 essentiality      = cell(size(genes));
 
 % Validate for gene essentiality
-progressbar('Checking for gene essentiality')
+PB = progressReport(numel(genes), 'Checking for gene essentiality');
 for i = 1:numel(genes)
+    PB.count;
 
     % Block protein usage to KO al the reactions associated to it.
     usage_rxn_idx = strcmpi(model.ec.genes, genes{i});
@@ -239,9 +240,8 @@ for i = 1:numel(genes)
     slope_set      = slope_rxns(rxns_for_gene);
     slope_genes(i) = mean(slope_set);
 
-    progressbar(i/numel(genes))
 end
-progressbar(1) % Make sure it closes
+PB.done;
 
 % Order genes from highest to lowest slope:
 [~,order]         = sort(slope_genes,'descend');

--- a/src/geckomat/utilities/ecFVA.m
+++ b/src/geckomat/utilities/ecFVA.m
@@ -41,12 +41,8 @@ if isempty(pool)
     parpool;
 end
 
-D = parallel.pool.DataQueue;
-progressbar('Running ecFVA');
-afterEach(D, @nUpdateProgressbar);
-
 N = numel(convRxnID);
-p = 1;
+PB = progressReport(N, 'Running ecFVA');
 
 parfor i=1:N
     tmpModel = ecModel;
@@ -70,8 +66,9 @@ parfor i=1:N
     if ~isempty(solMin.x)
         solMinAll(:,i)=solMin.x;
     end    
-    send(D, i);
+    count(PB);
 end
+PB.done;
 
 minFlux=min(solMinAll,[],2,'omitnan');
 maxFlux=max(solMaxAll,[],2,'omitnan');
@@ -89,8 +86,4 @@ if any(swapDir)
     maxFlux(swapDir) = tmpFlux;
 end
 
-function nUpdateProgressbar(~)
-progressbar(p/N);
-p = p + 1;
-end
 end


### PR DESCRIPTION
### Main improvements in this PR:

- Fixes:
  - `applyComplexData`, `findMetSmiles`, `getComplexData`, `fuzzyKcatMatching`, `getECfromDatabase`, `loadDatabases`, `ecFSEOF` and `ecFVA` called RAVEN's `progressbar`, which RAVEN removed in [RAVEN#623](https://github.com/SysBioChalmers/RAVEN/pull/623) in favour of the `progressReport` class. Against RAVEN `develop3` all eight errored with `Unrecognized function or variable 'progressbar'` before computing anything. Ported all 22 call sites (fixes #424).
- Refactor:
  - `ecFVA` no longer keeps its own `parallel.pool.DataQueue`, `afterEach` callback and shared counter. `progressReport` carries a DataQueue internally and `count` is parfor-safe, so the nested `nUpdateProgressbar` function goes away.
  - `loadDatabases` creates the reporter after the gene list is downloaded rather than before: `progressReport` takes the iteration count up front, and the number of queries is not known until then.
  - `findMetSmiles` finalises the reporter inside the branch that creates it. The old `progressbar(1)` sat at the end of the function, which is outside the `if any(~metMatch)` block that starts the bar.
- Chore:
  - `tests.yml` checks out RAVEN at `develop3` instead of taking its default branch. This is both why the break was invisible and what lets the tests run at all --- see below.

#### Instructions on merging this PR:
- [X] This PR has `develop` as target branch, and will be resolved with a *squash-merge*.
- [ ] This PR has `main` as target branch, and will be resolved with a *merge commit*.

---

#### The mapping

The three-call GECKO idiom maps onto the class directly:

```matlab
% before
progressbar('Task name')
for i = 1:N
    ...
    progressbar(i/N)
end
progressbar(1) % Make sure it closes

% after
PB = progressReport(N, 'Task name');
for i = 1:N
    PB.count;
    ...
end
PB.done;
```

`count` sits at the top of the loop body rather than the bottom, so that a pass ending in `continue` still advances the bar --- `applyComplexData` and `findMetSmiles` both have one, and under the old code those iterations were never counted. `PB.done` is only needed where a loop can exit early; `progressReport` finalises itself once the count reaches `N`.

#### Why CI did not catch this, and why it has to change with it

The `Checkout RAVEN` step took no `ref`, so CI cloned RAVEN's **default branch, `main`** --- which still ships `progressbar` in `software/progressbar/`. GECKO 4 is developed against RAVEN's `develop3` line, so CI has been testing a development branch against a release one, and every run was green while `develop3` users could not call `applyComplexData` at all.

That also means this PR cannot be merged without the CI change: `progressReport` exists only on `develop3`, so the ported code would fail against `main`.

#### Requires RAVEN develop3

`progressReport` is on RAVEN `develop3` and is not in any tagged release, so this raises GECKO's real RAVEN requirement. `GECKOInstaller.checkRAVENversion` cannot express that: it enforces a minimum version, and on a development branch `checkInstallation('versionOnly')` cannot determine a version at all --- it warns and continues. Worth bumping the floor once a RAVEN release carries #623.

Progress reporting also gets better on the way: the backend is chosen automatically (waitbar on a desktop, animated bar in a terminal, plain milestone lines with no control characters on a headless `-batch` runner, silent under a test suite) and can be forced with `setRavenProgress`.

#### Verification

`runtests('geckoCoreFunctionTests')` against RAVEN `develop3` (`4ea9b099`), MATLAB R2024b:

- **before:** `tc0003`, `tc0004`, `tc0007` and `tc0010` error on `Unrecognized function or variable 'progressbar'`; `tc0011`, `tc0012` and `tc0013` call the same functions.
- **after:** all thirteen cases pass.

Separately, GECKO and geckopy were run head to head on `ecTestGEM` through `applyComplexData`, `getECfromGEM` and `getECfromDatabase` (full and light ecModels, whole model and a subset of `ec.rxns`). All six checkpoints agree, so nothing here changes a result --- the ported functions produce what they always did, they just run again.
