### PR TITLE
fix: calculateFfactor loads the UniProt database it doesn't need, and its no-data fallback crashes

### DIFF
--- a/src/geckomat/limit_proteins/calculateFfactor.m
+++ b/src/geckomat/limit_proteins/calculateFfactor.m
@@ -61,14 +61,19 @@ if isempty(protData)
     else
         printOrange('WARNING: No proteomics data is provided or can be found. Default f value of 0.5 is returned.\n');
         f = 0.5;
+        return
     end
 end
 
-% Gather Uniprot database for finding MW
-uniprotDB = loadDatabases('uniprot', modelAdapter);
-uniprotDB = uniprotDB.uniprot;
-
 if ischar(protData) && endsWith(protData,'paxDB.tsv')
+    % Gather Uniprot database for finding MW. Only needed here, to map paxDB.tsv's gene
+    % identifiers onto UniProt IDs and molecular weights --- a protData struct supplied by
+    % the caller already carries UniProt IDs and needs no lookup, so this stays inside the
+    % branch that actually uses it rather than running (and potentially downloading or
+    % reading UniProt data) on every call.
+    uniprotDB = loadDatabases('uniprot', modelAdapter);
+    uniprotDB = uniprotDB.uniprot;
+
     fID         = fopen(fullfile(protData),'r');
     fileContent = textscan(fID,'%s','delimiter','\n');
     headerLines = find(startsWith(fileContent{1},'#'),1,'last');

--- a/test/unit_tests/geckoCoreFunctionTests.m
+++ b/test/unit_tests/geckoCoreFunctionTests.m
@@ -517,3 +517,17 @@ function testProteomcisIntegration_tc0013(testCase)
     verifyEqual(testCase,ecModel.ub(usageRxnIdx),flexEnz.flexConcs)
 end
 
+function testCalculateFfactor_tc0014(testCase)
+    geckoPath = findGECKOroot;
+    adapter = ModelAdapterManager.getAdapter(fullfile(geckoPath,'test','unit_tests','ecTestGEM', 'TestGEMAdapter.m'));
+    model = getGeckoTestModel();
+    ecModel = makeEcModel(model, false, adapter);
+
+    % ecTestGEM ships no data/paxDB.tsv, so with no protData supplied calculateFfactor must
+    % fall back to its documented default of 0.5 --- previously this crashed instead,
+    % since execution fell through past the default-0.5 branch and went on to index into
+    % protData as though it were the struct that branch never produced.
+    [~, f] = evalc("calculateFfactor(ecModel, [], [], adapter)");
+    verifyEqual(testCase,f,0.5)
+end
+


### PR DESCRIPTION
### Main improvements in this PR:

- Fixes:
  - `calculateFfactor` called `loadDatabases('uniprot', modelAdapter)` unconditionally, even
    though the result is only used inside the branch that parses a raw `data/paxDB.tsv` file.
    A caller-supplied `protData` struct --- the common path, e.g. from `loadProtData` --- already
    carries UniProt IDs and never touched `uniprotDB`, so every such call did a pointless
    database load (a local read at best, a network download at worst if `data/uniprot.tsv`
    is missing). Moved the load inside the `paxDB.tsv` branch, next to its only use.
  - When no `protData` is supplied and no `data/paxDB.tsv` exists, `calculateFfactor` is
    documented to fall back to `f = 0.5` with a warning. It didn't: `f = 0.5` was set but
    execution fell through instead of returning, then crashed a few lines later trying to
    read `.abundances` off the empty `protData` it never populated. Added the missing
    `return`.
- Tests:
  - Added `testCalculateFfactor_tc0014`, covering the no-data fallback --- ecTestGEM ships no
    `paxDB.tsv`, so this is exactly the path that used to crash. There was no existing test
    for `calculateFfactor` at all.

#### Instructions on merging this PR:
- [X] This PR has `develop` as target branch, and will be resolved with a *squash-merge*.
- [ ] This PR has `main` as target branch, and will be resolved with a *merge commit*.

---

Both issues are in the same handful of lines, found while building a cross-implementation
parity scenario in
[SysBioChalmers/raven-gecko-parity](https://github.com/SysBioChalmers/raven-gecko-parity)
that runs `calculateFfactor` against geckopy's `calculate_f_factor` with a real `protData`
struct on both sides. The unnecessary load doesn't change the result --- both scenario runs
already matched before this fix --- so this is a correctness and performance cleanup, not a
behaviour change; re-run after the fix, still matches.

The second issue is a genuine, previously-unreachable-by-tests crash: `f = 0.5` is what the
docstring promises for "no proteomics data is provided or can be found", and until this PR
that promise errored instead.

#### Verification

`runtests('geckoCoreFunctionTests')` against RAVEN `develop3`: all fourteen cases pass,
including the new one. Before this fix, the equivalent manual call
(`calculateFfactor(ecModel, [], [], adapter)` with no `paxDB.tsv` present) threw
`Dot indexing is not supported for variables of this type.` from the `mean(protData.abundances,2)`
line; after, it returns `0.5` as documented.
