### PR TITLE
fix: addNewRxnsToEC loses track of which reaction it is splitting when more than one needs isozyme expansion

### DIFF
--- a/src/geckomat/utilities/addNewRxnsToEC.m
+++ b/src/geckomat/utilities/addNewRxnsToEC.m
@@ -170,24 +170,34 @@ else
     % Get reactions to separate isozymes
     toSplit = find(cellfun(@(x) contains(x,'or'),newRxns.grRules));
     if ~isempty(toSplit)
+        splitRxns = {}; splitRxnNames = {}; splitEquations = {}; splitGrRules = {};
         for i=1:numel(toSplit)
             idx = toSplit(i);
             newRules = split(newRxns.grRules(idx),'or');
             newRules = strtrim(erase(newRules, {'(' ')'}));
 
             for j=1:numel(newRules)
-                newRxns.rxns{end+1} = [newRxns.rxns{idx} '_EXP_' num2str(j)];
-                newRxns.rxnNames(end+1) = newRxns.rxnNames(idx);
-                newRxns.equations(end+1) = newRxns.equations(idx);
-                newRxns.grRules(end+1) = newRules(j);
+                splitRxns{end+1} = [newRxns.rxns{idx} '_EXP_' num2str(j)];
+                splitRxnNames(end+1) = newRxns.rxnNames(idx);
+                splitEquations(end+1) = newRxns.equations(idx);
+                splitGrRules(end+1) = newRules(j);
             end
-
-            % Remove the original one
-            newRxns.rxns(idx) = [];
-            newRxns.rxnNames(idx) = [];
-            newRxns.equations(idx) = [];
-            newRxns.grRules(idx) = [];
         end
+
+        % Remove every original that was split, in one indexed operation, then append
+        % the replacements. Removing (or appending) one at a time while iterating a list
+        % of indices computed up front lets each removal shift the indices of everything
+        % after it, so a second (or later) original silently gets read from the wrong
+        % position once more than one reaction needs splitting in the same call.
+        newRxns.rxns(toSplit) = [];
+        newRxns.rxnNames(toSplit) = [];
+        newRxns.equations(toSplit) = [];
+        newRxns.grRules(toSplit) = [];
+
+        newRxns.rxns = [newRxns.rxns(:); splitRxns(:)];
+        newRxns.rxnNames = [newRxns.rxnNames(:); splitRxnNames(:)];
+        newRxns.equations = [newRxns.equations(:); splitEquations(:)];
+        newRxns.grRules = [newRxns.grRules(:); splitGrRules(:)];
     end
 
     newRxns.lb = zeros(length(newRxns.rxns),1);

--- a/test/unit_tests/geckoCoreFunctionTests.m
+++ b/test/unit_tests/geckoCoreFunctionTests.m
@@ -531,3 +531,59 @@ function testCalculateFfactor_tc0014(testCase)
     verifyEqual(testCase,f,0.5)
 end
 
+function testAddNewRxnsToEC_tc0015(testCase)
+    geckoPath = findGECKOroot;
+    adapter = ModelAdapterManager.getAdapter(fullfile(geckoPath,'test','unit_tests','ecTestGEM', 'TestGEMAdapter.m'));
+    model = getGeckoTestModel();
+    ecModel = makeEcModel(model, false, adapter);
+
+    % Two new reactions, each with its own isozyme (OR) grRule, added in the same call.
+    % Regression test: addNewRxnsToEC used to lose track of which reaction it was
+    % splitting once more than one needed splitting. It removed (and appended) one entry
+    % at a time while iterating a list of indices computed before any removal, so each
+    % removal shifted the positions of every later entry --- the second (and any further)
+    % reaction's grRule was then read from whatever had shifted into its old position,
+    % rather than its own.
+    newRxns.rxns      = {'RNEWA'; 'RNEWB'};
+    newRxns.rxnNames  = {'RNEWA'; 'RNEWB'};
+    newRxns.equations = {'m1[c] => e2[e]'; 'm2[c] => e1[e]'};
+    newRxns.grRules   = {'GNEW1 or GNEW2'; 'GNEW3 or GNEW4'};
+
+    newEnzymes.enzymes = {'ENEW1'; 'ENEW2'; 'ENEW3'; 'ENEW4'};
+    newEnzymes.genes   = {'GNEW1'; 'GNEW2'; 'GNEW3'; 'GNEW4'};
+    newEnzymes.mw      = [15000; 25000; 35000; 45000];
+
+    [ecModel, rxnsAdded, enzAdded] = addNewRxnsToEC(ecModel, newRxns, newEnzymes, adapter);
+
+    expRxnsAdded = {'RNEWA_EXP_1'; 'RNEWA_EXP_2'; 'RNEWB_EXP_1'; 'RNEWB_EXP_2'};
+    verifyEqual(testCase, sort(rxnsAdded), sort(expRxnsAdded))
+    verifyEqual(testCase, sort(enzAdded), sort(newEnzymes.enzymes))
+
+    % Each split reaction must carry exactly the one gene it was split from --- not the
+    % unsplit "X or Y" string the bug left on the second (and later) reaction, nor a
+    % double-suffixed id from re-splitting an already-split entry.
+    [~, idxA1] = ismember('RNEWA_EXP_1', ecModel.rxns);
+    [~, idxA2] = ismember('RNEWA_EXP_2', ecModel.rxns);
+    [~, idxB1] = ismember('RNEWB_EXP_1', ecModel.rxns);
+    [~, idxB2] = ismember('RNEWB_EXP_2', ecModel.rxns);
+    verifyEqual(testCase, ecModel.grRules{idxA1}, 'GNEW1')
+    verifyEqual(testCase, ecModel.grRules{idxA2}, 'GNEW2')
+    verifyEqual(testCase, ecModel.grRules{idxB1}, 'GNEW3')
+    verifyEqual(testCase, ecModel.grRules{idxB2}, 'GNEW4')
+
+    % And the enzyme-coupling matrix must reflect the same one-gene-per-split-reaction
+    % mapping.
+    [~, ecA1] = ismember('RNEWA_EXP_1', ecModel.ec.rxns);
+    [~, ecA2] = ismember('RNEWA_EXP_2', ecModel.ec.rxns);
+    [~, ecB1] = ismember('RNEWB_EXP_1', ecModel.ec.rxns);
+    [~, ecB2] = ismember('RNEWB_EXP_2', ecModel.ec.rxns);
+    [~, enz1] = ismember('ENEW1', ecModel.ec.enzymes);
+    [~, enz2] = ismember('ENEW2', ecModel.ec.enzymes);
+    [~, enz3] = ismember('ENEW3', ecModel.ec.enzymes);
+    [~, enz4] = ismember('ENEW4', ecModel.ec.enzymes);
+    verifyEqual(testCase, ecModel.ec.rxnEnzMat(ecA1, enz1), 1)
+    verifyEqual(testCase, ecModel.ec.rxnEnzMat(ecA2, enz2), 1)
+    verifyEqual(testCase, ecModel.ec.rxnEnzMat(ecB1, enz3), 1)
+    verifyEqual(testCase, ecModel.ec.rxnEnzMat(ecB2, enz4), 1)
+end
+


### PR DESCRIPTION
### Main improvements in this PR:

- Fixes:
  - `addNewRxnsToEC` crashed with `Index in position 2 is invalid` whenever more than one
    reaction in a single call needed isozyme (OR-grRule) expansion --- including a single
    *reversible* reaction with an isozyme grRule, since the reversibility split duplicates
    that grRule onto a second entry before the isozyme split runs. Root cause: the split
    loop mutated the arrays it was iterating over, using indices computed before any
    mutation, so each removal shifted every later entry's position and a later index no
    longer pointed at the reaction it was meant to.
- Tests:
  - Added `testAddNewRxnsToEC_tc0015`: two new reactions, each with its own isozyme grRule,
    in one call. There was no existing test for `addNewRxnsToEC` at all.

#### Instructions on merging this PR:
- [X] This PR has `develop` as target branch, and will be resolved with a *squash-merge*.
- [ ] This PR has `main` as target branch, and will be resolved with a *merge commit*.

---

#### Reproduce

```matlab
newRxns.rxns      = {'RNEWA'; 'RNEWB'};
newRxns.rxnNames  = {'RNEWA'; 'RNEWB'};
newRxns.equations = {'m1[c] => e2[e]'; 'm2[c] => e1[e]'};
newRxns.grRules   = {'GNEW1 or GNEW2'; 'GNEW3 or GNEW4'};
newEnzymes.enzymes = {'ENEW1';'ENEW2';'ENEW3';'ENEW4'};
newEnzymes.genes   = {'GNEW1';'GNEW2';'GNEW3';'GNEW4'};
newEnzymes.mw      = [15000;25000;35000;45000];

addNewRxnsToEC(ecModel, newRxns, newEnzymes, adapter);
```
```
Index in position 2 is invalid. Array indices must be positive integers or logical values.
Error in addNewRxnsToEC (line 247)
        model.ec.rxnEnzMat(numRxns+i, enzIdx) = 1;
```

#### Why

`toSplit = find(cellfun(@(x) contains(x,'or'),newRxns.grRules));` computes the indices of
every entry needing a split, once, before the loop starts. Each loop iteration then does
`newRxns.rxns(idx) = []` --- removing one entry shifts every later entry left by one. With
`toSplit = [1, 2]`: iteration 1 splits index 1 correctly, then removes it, and everything
that was at index 2 (the *second* reaction needing a split) is now at index 1, while index 2
is one of the brand-new entries iteration 1 just appended. Iteration 2 then "splits" that
new entry instead (its grRule has no `or`, so `split` returns it unchanged, producing a
double-suffixed id `..._EXP_1_EXP_1`), and the actual second reaction's grRule is left
unsplit. Its `"GENE1 or GENE2"` string then gets looked up as if it were one gene name a few
lines later, `ismember` reports no match, and indexing `rxnEnzMat` with that `0` throws.

#### Fix

Collect every split's replacement rows from the original, unmutated arrays first; remove
every original that needed splitting in one indexed operation (`newRxns.rxns(toSplit) = []`,
which MATLAB performs atomically regardless of how many indices); append all replacements
after. No removal happens until every read is done, so nothing can shift out from under a
later iteration.

#### Verification

`runtests('geckoCoreFunctionTests')` against RAVEN `develop3`: all fifteen cases pass,
including the new one. Also verified against
[raven-gecko-parity](https://github.com/SysBioChalmers/raven-gecko-parity)'s
`model_edits_ectestgem` scenario, which adds a reversible, isozyme-catalysed reaction (the
combination this bug needed) and compares the result against geckopy's
`add_new_rxns_to_ec` on the same input: the two agree on the reactions added, the enzymes
added, and every reaction, gene association, stoichiometric coefficient and `ec.*` field
in the resulting model.
