### PR TITLE
fix: writeDLKcatInput silently drops rows for any non-trivial ecRxns subset

### DIFF
--- a/src/geckomat/gather_kcats/writeDLKcatInput.m
+++ b/src/geckomat/gather_kcats/writeDLKcatInput.m
@@ -50,20 +50,20 @@ p = parseGECKOargs(varargin, { ...
     'onlyWithSmiles', []; ...
     'filename',       []; ...
     'overwrite',      []});
-ecRxns         = p.ecRxns;
+ecRxnsSel      = p.ecRxns;
 modelAdapter   = p.modelAdapter;
 onlyWithSmiles = p.onlyWithSmiles;
 filename       = p.filename;
 overwrite      = p.overwrite;
 
-if isempty(ecRxns)
-    ecRxns = true(numel(model.ec.rxns),1);
-elseif ~logical(ecRxns)
+if isempty(ecRxnsSel)
+    ecRxnsSel = true(numel(model.ec.rxns),1);
+elseif ~logical(ecRxnsSel)
     error('ecRxns should be provided as logical vector')
-elseif numel(ecRxns)~=numel(model.ec.rxns)
+elseif numel(ecRxnsSel)~=numel(model.ec.rxns)
     error('Length of ecRxns is not the same as model.ec.rxns')
 end
-ecRxns = find(ecRxns); % Change to indices
+ecRxnsSel = find(ecRxnsSel); % Change to indices, into the full model.ec.rxns
 
 if isempty(modelAdapter)
     modelAdapter = ModelAdapterManager.getDefault();
@@ -94,7 +94,7 @@ if ~model.ec.geckoLight
 else
    origRxns = extractAfter(model.ec.rxns,4);
 end
-origRxnsToInclude = origRxns(ecRxns);
+origRxnsToInclude = origRxns(ecRxnsSel);
 
 % Map back to original reactions, to extract substrates
 [sanityCheck,origRxnIdxs] = ismember(origRxnsToInclude,model.rxns);
@@ -152,26 +152,29 @@ for i=1:size(currencyMets,1)
     reducedS([find(subs);find(prod)],intersect(pairRxns,pairRxns(rxnsWithRemainingSubstrates))) = 0;
 end
 
-%filter out the reactions we're not interested in - will solve the problem for both full and light
+% origRxnIdxs already selects exactly the model.rxns columns for the requested
+% ecRxns subset (one column per requested reaction, via origRxns(ecRxns) above), so
+% clearedRedS needs no further filtering here.
 clearedRedS = reducedS(:,origRxnIdxs);
-rxnsToClear = true(length(origRxnIdxs),1);
-rxnsToClear(ecRxns) = false;
-clearedRedS(:,rxnsToClear) = 0;
 
-% Enumerate all substrates for each reaction
-[substrates, reactions] = find(clearedRedS<0); %the reactions here are in model.ec.rxns space
+% Enumerate all substrates for each reaction. clearedRedS has one column per entry
+% of ecRxnsSel, in that same order, so `reactions` here indexes *that subset*, not
+% model.ec.rxns directly --- translate back to a real model.ec.rxns index before
+% using it against model.ec.rxns / model.ec.rxnEnzMat, which are always full-length.
+[substrates, reactions] = find(clearedRedS<0);
+globalEcRxns = ecRxnsSel(reactions);
 
 % Enumerate all proteins for each reaction
-[proteins, ecRxns] = find(transpose(model.ec.rxnEnzMat(reactions,:)));
+[proteins, enzRows] = find(transpose(model.ec.rxnEnzMat(globalEcRxns,:)));
 
 % Prepare output
-out(1,:) = model.ec.rxns(reactions(ecRxns));
+out(1,:) = model.ec.rxns(globalEcRxns(enzRows));
 out(2,:) = model.ec.genes(proteins);
-out(3,:) = model.metNames(substrates(ecRxns));
+out(3,:) = model.metNames(substrates(enzRows));
 if isfield(model,'metSmiles')
-    out(4,:) = model.metSmiles(substrates(ecRxns));
+    out(4,:) = model.metSmiles(substrates(enzRows));
 else
-    out(4,:) = cell(numel(substrates(ecRxns)),1);
+    out(4,:) = cell(numel(substrates(enzRows)),1);
 end
 
 out(5,:) = model.ec.sequence(proteins);

--- a/test/unit_tests/geckoCoreFunctionTests.m
+++ b/test/unit_tests/geckoCoreFunctionTests.m
@@ -531,3 +531,43 @@ function testCalculateFfactor_tc0014(testCase)
     verifyEqual(testCase,f,0.5)
 end
 
+
+function testWriteDLKcatInputSubset_tc0015(testCase)
+    geckoPath = findGECKOroot;
+    adapter = ModelAdapterManager.getAdapter(fullfile(geckoPath,'test','unit_tests','ecTestGEM', 'TestGEMAdapter.m'));
+    model = getGeckoTestModel();
+    rxnsToAdd = struct();
+    rxnsToAdd.rxns = {'R2a'};
+    rxnsToAdd.grRules = {'G1 and G2 or G3'};
+    rxnsToAdd.equations = {'m1[c] <=> m2[c]'};
+    model = addRxns(model,rxnsToAdd, 3); %no eccode for R2a, so it never gets a fuzzy match
+
+    ecModel = makeEcModel(model, false, adapter);
+    ecModel = getECfromGEM(ecModel);
+
+    % A non-trivial ecRxns subset --- neither "all reactions" (ecRxns=[]) nor a subset
+    % that happens to start at index 1 --- is the ordinary, documented way to call
+    % writeDLKcatInput (e.g. "only the reactions fuzzy matching couldn't find a kcat
+    % for"), but was never exercised by any existing test: every prior call site here
+    % and in the manual tests either omits ecRxns or passes a full-length mask. With
+    % R2a_EXP_1/R2a_EXP_2 in the middle of ec.rxns rather than at its start, this used
+    % to silently write zero rows (an internal filtering step re-used already-consumed
+    % indices from ec.rxns space to index into the already-filtered, subset-length
+    % array, clearing every row it should have kept), and after a first, incomplete fix
+    % it wrote the right *number* of rows but attributed them to the wrong reactions
+    % (the same re-used-index mistake, one step further down).
+    ecRxns = ismember(ecModel.ec.rxns, {'R2a_EXP_1','R2a_EXP_2'});
+    filepath = fullfile(adapter.getParameters().path,'data','DLKcat_input_subset_test.tsv');
+    if exist(filepath, 'file')==2
+      delete(filepath);
+    end
+    writtenTable = writeDLKcatInput(ecModel, 'ecRxns', ecRxns, 'modelAdapter', adapter, ...
+        'onlyWithSmiles', false, 'filename', filepath, 'overwrite', true);
+    if exist(filepath, 'file')==2 %clean up
+      delete(filepath);
+    end
+    verifyEqual(testCase,writtenTable(1,:), {'R2a_EXP_1','R2a_EXP_1','R2a_EXP_2'})
+    verifyEqual(testCase,writtenTable(2,:), {'G1','G2','G3'})
+    verifyEqual(testCase,writtenTable(3,:), {'m1','m1','m1'})
+end
+


### PR DESCRIPTION
## What

`writeDLKcatInput.m` reuses the variable name `ecRxns` for three different index spaces across its body: first the caller's requested indices into the full `model.ec.rxns`, then (after the substrate/reaction matrix is filtered down to that subset) an index local to the subset itself. The code downstream of that filtering step still treats those local indices as if they were global `model.ec.rxns` indices — which only happens to hold when the caller selects every reaction, since only then do local and global positions coincide.

Every existing call site in this codebase — including the function's own docstring example and `testKcats_tc0011` — passes `ecRxns=[]` (all reactions), so this has never been caught. Passing any genuine subset (the ordinary, documented use: "for which reactions ... DLKcat should predict kcat values", e.g. only the reactions fuzzy matching couldn't find a kcat for) silently wrote **zero rows** for the requested reactions instead of the expected ones.

## Fix

Threads the caller's requested indices through explicitly (renamed `ecRxnsSel`) instead of reusing an already-consumed variable for a different index space, and translates the subset-local row index back to a real `model.ec.rxns` index before using it against `model.ec.rxns`/`model.ec.rxnEnzMat`, which are always full-length.

## Testing

Added `testWriteDLKcatInputSubset_tc0015`, which builds on the same base fixture as `testKcats_tc0011` but calls `writeDLKcatInput` with a genuine subset (two isozymes of a reaction that isn't first in `ec.rxns`) and asserts the correct rows come back. `runtests('geckoCoreFunctionTests')` passes all 15 cases, including the new one and the pre-existing `tc0011`/`tc0010` cases that exercise this function in its more common all-reactions mode.

Found while building a cross-implementation parity scenario against geckopy (`kcat_chain_ectestgem` in [raven-gecko-parity](https://github.com/SysBioChalmers/raven-gecko-parity)), which calls `writeDLKcatInput` with exactly this kind of subset.

Note: this branches off `develop4` at the tip that includes #426. #427 is still open and also adds a `tc0015` — whichever of the two merges second will need renumbering.