### PR TITLE
fix: TestGEMAdapter.getSpontaneousReactions crashed, then broke on the expanded ecModel

### DIFF
--- a/test/unit_tests/ecTestGEM/TestGEMAdapter.m
+++ b/test/unit_tests/ecTestGEM/TestGEMAdapter.m
@@ -38,9 +38,12 @@ classdef TestGEMAdapter < ModelAdapter
         end
 		
 		function [spont,spontRxnNames] = getSpontaneousReactions(obj,model)
-			spont = false(length(model.rxns), 1);
-			spontRxnNames = rxns_tsv.rxns;
-			spont(5) = true; %R4 is spontaneous
+			% Matched by reaction id rather than a hardcoded position: this is
+			% called with the ecModel (already expanded into isozyme/reversibility
+			% variants) by getStandardKcat, not the plain 7-reaction conventional
+			% model, and R4's position among model.rxns is not the same in both.
+			spont = strcmp(model.rxns, 'R4');
+			spontRxnNames = model.rxnNames(spont);
         end
         
         function folder = getBrendaDBFolder(obj)

--- a/test/unit_tests/geckoCoreFunctionTests.m
+++ b/test/unit_tests/geckoCoreFunctionTests.m
@@ -531,3 +531,29 @@ function testCalculateFfactor_tc0014(testCase)
     verifyEqual(testCase,f,0.5)
 end
 
+
+function testTestGEMAdapterSpontaneousReactions_tc0016(testCase)
+    geckoPath = findGECKOroot;
+    adapter = ModelAdapterManager.getAdapter(fullfile(geckoPath,'test','unit_tests','ecTestGEM', 'TestGEMAdapter.m'));
+
+    % getSpontaneousReactions used to reference an undefined variable
+    % (rxns_tsv.rxns) and crash unconditionally whenever called -- this is the
+    % only method that ever calls it (from getStandardKcat.m), so
+    % getStandardKcat could never run against TestGEMAdapter at all.
+    model = getGeckoTestModel();
+    [spont, spontRxnNames] = adapter.getSpontaneousReactions(model);
+    verifyEqual(testCase,find(spont),5)
+    verifyEqual(testCase,spontRxnNames,{'R4'})
+
+    % Fixing the undefined variable alone was not enough: the position it set
+    % (spont(5) = true) is only valid for this 7-reaction conventional model.
+    % getStandardKcat's only real caller passes the already-expanded ecModel,
+    % where R4's position among model.rxns has moved -- matching by reaction
+    % id instead of position (mirroring geckopy's own TestGEMAdapter port)
+    % survives that.
+    ecModel = makeEcModel(model, false, adapter);
+    [spontEc, spontRxnNamesEc] = adapter.getSpontaneousReactions(ecModel);
+    verifyEqual(testCase,find(spontEc),find(strcmp(ecModel.rxns,'R4')))
+    verifyEqual(testCase,spontRxnNamesEc,{'R4'})
+end
+


### PR DESCRIPTION
## What

`TestGEMAdapter.getSpontaneousReactions` had two bugs, found together while building a cross-implementation parity scenario against geckopy (`kcat_chain_ectestgem` in [raven-gecko-parity](https://github.com/SysBioChalmers/raven-gecko-parity)):

1. It referenced an undefined variable, `rxns_tsv.rxns` — this method is the **only** call site of `getSpontaneousReactions` anywhere in GECKO (it's called from `getStandardKcat.m`), so `getStandardKcat` could never actually run against `TestGEMAdapter` at all; it crashed immediately.
2. Fixing that alone isn't enough: the method hardcodes `spont(5) = true`, valid only for the plain 7-reaction conventional model (`S1, R1, R2, R3, R4, R5, S2`). `getStandardKcat`'s real call passes the already-*expanded* ecModel, where `R4`'s position among `model.rxns` has moved once `R2` is split into its isozyme/reversibility variants ahead of it — so the wrong reaction gets flagged spontaneous (or, with a small model, an out-of-range index).

Between the two, `getStandardKcat` — called the intended way, against `TestGEMAdapter` — has apparently never actually worked.

## Fix

Matches by reaction id instead of position, mirroring how geckopy's own port of this adapter (`examples/ecTestGEM/adapter.py`) already solved the identical problem, down to the same reasoning in its own comment: *"Using the reaction ID rather than the index is more robust to reordering by cobrapy's SBML parser."*

## Testing

Added `testTestGEMAdapterSpontaneousReactions_tc0016`, asserting `getSpontaneousReactions` returns `R4` correctly both against the plain conventional model and against the expanded ecModel. `runtests('geckoCoreFunctionTests')` passes all 15 cases.

`getStandardKcat.m`/`removeStandardKcat.m` have no other test coverage at all — `test/VerificationMatrix.tsv` records the former with empty Verification/Comments columns, and the latter isn't listed there at all — so this PR is scoped to the adapter bug specifically rather than also being the first real test of `getStandardKcat`'s own logic, which the parity scenario linked above exercises instead.

Note: this branches off `develop4` at the tip that includes #426, alongside #428 (same base, unrelated fix, also touches `geckoCoreFunctionTests.m`) and the still-open #427, both of which also add a `tc0015`. This PR uses `tc0016` to avoid a collision with #428; whichever of #427/#428/this merges last will still need a look at the numbering.