### PR TITLE
fix: applyKcatConstraints overwrites instead of summing duplicate enzyme accessions

### DIFF
--- a/src/geckomat/change_model/applyKcatConstraints.m
+++ b/src/geckomat/change_model/applyKcatConstraints.m
@@ -110,7 +110,14 @@ if ~model.ec.geckoLight
         [~,newKcats(:,1)] = ismember(model.ec.rxns(newKcats(:,1)),model.rxns);
         [~,newKcats(:,2)] = ismember(strcat('prot_',model.ec.enzymes(newKcats(:,2))),model.mets);
         linearIndices     = sub2ind(size(model.S),newKcats(:,2),newKcats(:,1));
-        model.S(linearIndices) = -newKcats(:,4); %Substrate = negative
+        %Two enzyme rows can map to the same prot_<accession> metabolite (distinct
+        %genes sharing one UniProt entry), giving a repeated linear index here. A
+        %plain indexed assignment on a repeated index keeps only the last value
+        %written, silently dropping the other enzyme's contribution instead of
+        %adding it, so accumulate per unique index instead.
+        [uniqueIndices,~,linearIndicesToUnique] = unique(linearIndices);
+        summedValues = accumarray(linearIndicesToUnique,-newKcats(:,4));
+        model.S(uniqueIndices) = summedValues; %Substrate = negative
     end
 else %GECKO light formulation, where prot_pool represents all usages
     prot_pool_idx = find(ismember(model.mets,'prot_pool'));

--- a/test/unit_tests/geckoCoreFunctionTests.m
+++ b/test/unit_tests/geckoCoreFunctionTests.m
@@ -597,3 +597,28 @@ function testTestGEMAdapterSpontaneousReactions_tc0016(testCase)
     verifyEqual(testCase,spontRxnNamesEc,{'R4'})
 end
 
+
+function testApplyKcatConstraintsDuplicateAccession_tc0017(testCase)
+    % Two ec.enzymes rows can map to the same prot_<accession> metabolite --
+    % distinct genes sharing one UniProt entry. applyKcatConstraints used to
+    % write model.S(linearIndices) = -newKcats(:,4) directly: a plain indexed
+    % assignment on a repeated linear index keeps only the last value written,
+    % silently dropping one enzyme's contribution instead of adding it to the
+    % other's.
+    clear model
+    model.rxns = {'R1'};
+    model.mets = {'prot_P1'};
+    model.S = sparse(1,1);
+    model.lb = -1000; model.ub = 1000;
+    model.ec.geckoLight = false;
+    model.ec.rxns = {'R1'};
+    model.ec.kcat = 100;
+    model.ec.enzymes = {'P1'; 'P1'};
+    model.ec.mw = [10000; 20000];
+    model.ec.rxnEnzMat = sparse([1 1]);
+
+    model = applyKcatConstraints(model);
+    expected = -(10000+20000)/100/3600; %summed, not just the second row's -20000/100/3600
+    verifyEqual(testCase,full(model.S(1,1)),expected,'AbsTol',1e-12)
+end
+


### PR DESCRIPTION
Closes #430.

## What

In the full formulation, two `ec.enzymes` rows can map to the same `prot_<accession>` metabolite for the same reaction — distinct genes sharing one UniProt entry. The final write applies the whole batch in one indexed assignment:

```matlab
linearIndices     = sub2ind(size(model.S),newKcats(:,2),newKcats(:,1));
model.S(linearIndices) = -newKcats(:,4); %Substrate = negative
```

MATLAB's indexed assignment on a repeated linear index keeps only the **last** value written, not a sum:

```matlab
>> A = zeros(1,3); A([2 2]) = [10 20]; A
A = 0  20  0
```

So one enzyme's contribution to that reaction's cost was silently dropped instead of being added to the other's.

Confirmed by direct execution: one reaction, one accession `P1` appearing twice (MW 10000 and 20000, kcat 100) gave a coefficient of `-20000/100/3600` (the second row only) instead of `-(10000+20000)/100/3600` (the sum) — exactly matching geckopy's `apply_kcat_constraints`, which sums explicitly and has its own dedicated regression test (`test_duplicate_accession_coeffs_sum`).

## Fix

Accumulates per unique linear index (`unique` + `accumarray`) before writing, instead of assigning the whole batch directly. Deliberately not a naive `accumarray(linearIndices, ...)` — that would allocate a dense array sized to the full `model.S`, which is fine for `ecTestGEM` but not for a genome-scale model.

## Testing

Added `testApplyKcatConstraintsDuplicateAccession_tc0017` with a duplicated accession, asserting the summed coefficient. Confirmed no regression on the existing single-enzyme, multi-subunit-complex, and light-model paths, plus `testKcats_tc0011`'s own `applyKcatConstraints` assertions on the shared fixture. `runtests('geckoCoreFunctionTests')` passes all 17 cases.

Found while building a cross-implementation parity scenario against geckopy (`kcat_chain_ectestgem` in [raven-gecko-parity](https://github.com/SysBioChalmers/raven-gecko-parity)), same as #428/#429.