### PR TITLE
Fix reportEnzymeUsage crash on models with fewer than topAbsUsage enzymes

### DIFF
--- a/src/geckomat/utilities/reportEnzymeUsage.m
+++ b/src/geckomat/utilities/reportEnzymeUsage.m
@@ -42,6 +42,14 @@ highCapUsage = p.highCapUsage;
 topAbsUsage  = p.topAbsUsage;
 if isempty(highCapUsage); highCapUsage = 0.9; end
 if isempty(topAbsUsage);  topAbsUsage  = 10;  end
+% 0 or Inf means "all enzymes", per the docstring above -- and any topAbsUsage at or
+% above the enzyme count means the same thing in practice, but unlike those two special
+% values it used to reach the indexing below unclamped: usageData.protID(topUse(1:N))
+% with N > numel(topUse) is an out-of-bounds index, so any model with fewer than 10
+% enzymes (ecTestGEM has 5) crashed on the default call.
+if topAbsUsage == 0 || isinf(topAbsUsage) || topAbsUsage > numel(usageData.protID)
+    topAbsUsage = numel(usageData.protID);
+end
 
 usageReport = {};
 

--- a/test/unit_tests/geckoCoreFunctionTests.m
+++ b/test/unit_tests/geckoCoreFunctionTests.m
@@ -678,3 +678,38 @@ function testAddNewRxnsToEC_tc0018(testCase)
     verifyEqual(testCase, ecModel.ec.rxnEnzMat(ecB2, enz4), 1)
 end
 
+
+function testReportEnzymeUsageTopAbsUsageOutOfBounds_tc0019(testCase)
+    % reportEnzymeUsage's default topAbsUsage (10) used to reach
+    % usageData.protID(topUse(1:topAbsUsage)) unclamped: on any model with fewer
+    % than 10 enzymes -- ecTestGEM has 5 -- that indexed past the end of topUse
+    % and crashed. Regression test for the default call, plus the two other
+    % "all enzymes" spellings the docstring promises (0 and Inf), plus an
+    % ordinary in-range value left unaffected.
+    geckoPath = findGECKOroot;
+    adapter = ModelAdapterManager.getAdapter(fullfile(geckoPath,'test','unit_tests','ecTestGEM', 'TestGEMAdapter.m'));
+    model = getGeckoTestModel();
+    ecModel = makeEcModel(model, false, adapter);
+    ecModel = getECfromGEM(ecModel);
+    ecModel.ec.kcat(:) = 100;
+    ecModel.ec.source(:) = {'manual'};
+    ecModel = applyKcatConstraints(ecModel);
+    ecModel = setProtPoolSize(ecModel, [], [], [], adapter);
+
+    fluxes = zeros(numel(ecModel.rxns),1);
+    usageData = enzymeUsage(ecModel, fluxes);
+    nEnz = numel(usageData.protID);
+
+    report = reportEnzymeUsage(ecModel, usageData);
+    verifyEqual(testCase, height(report.topAbsUsage), nEnz)
+
+    report = reportEnzymeUsage(ecModel, usageData, 'topAbsUsage', 0);
+    verifyEqual(testCase, height(report.topAbsUsage), nEnz)
+
+    report = reportEnzymeUsage(ecModel, usageData, 'topAbsUsage', Inf);
+    verifyEqual(testCase, height(report.topAbsUsage), nEnz)
+
+    report = reportEnzymeUsage(ecModel, usageData, 'topAbsUsage', 2);
+    verifyEqual(testCase, height(report.topAbsUsage), 2)
+end
+


### PR DESCRIPTION
## Summary
- `reportEnzymeUsage`'s default `topAbsUsage` (10) reaches `usageData.protID(topUse(1:topAbsUsage))` unclamped, so any model with fewer than 10 enzymes crashes on the default call with an out-of-bounds index. ecTestGEM has 5 enzymes, so this crashed the moment anyone called `reportEnzymeUsage` against it without overriding `topAbsUsage`.
- The docstring already promises that `0` or `Inf` means "all enzymes"; the fix extends that same clamp to any `topAbsUsage` at or above the enzyme count, since that already means the same thing in practice.
- Found while building a cross-implementation parity scenario for `enzymeUsage`/`reportEnzymeUsage`/`getConcControlCoeffs` against ecTestGEM in raven-gecko-parity.

## Test plan
- [x] Added `testReportEnzymeUsageTopAbsUsageOutOfBounds_tc0019` to `geckoCoreFunctionTests.m`, covering the default call, `topAbsUsage=0`, `topAbsUsage=Inf`, and an ordinary in-range value.
- [x] Full suite: `runtests('geckoCoreFunctionTests.m')` -- 19 passed, 0 failed.
