### PR TITLE
Fix sigmaFitter returning a model sized for the wrong sigma

### DIFF
--- a/src/geckomat/kcat_sensitivity_analysis/sigmaFitter.m
+++ b/src/geckomat/kcat_sensitivity_analysis/sigmaFitter.m
@@ -97,6 +97,12 @@ for i=1:100
 end
 [~, minIndx] = min(errors);
 sigma     = sigParam(minIndx);
+% The loop above leaves the protein pool sized for the *last* sigma tried
+% (i=100, i.e. sigma=1), not the best-fitting one found by the search --
+% re-apply it here so the returned model actually matches the returned
+% sigma, per this function's own documented contract ("ecModel with
+% protein pool exchange upper bound adapted to the optimal sigma-factor").
+model = setProtPoolSize(model, Ptot, f, sigma, modelAdapter);
 if makePlot
     figure
     plot(sigParam,errors,'LineWidth',5)

--- a/test/unit_tests/geckoCoreFunctionTests.m
+++ b/test/unit_tests/geckoCoreFunctionTests.m
@@ -713,3 +713,36 @@ function testReportEnzymeUsageTopAbsUsageOutOfBounds_tc0019(testCase)
     verifyEqual(testCase, height(report.topAbsUsage), 2)
 end
 
+
+function testSigmaFitterModelMatchesReturnedSigma_tc0020(testCase)
+    % sigmaFitter's own docstring promises the returned model has its protein
+    % pool "adapted to the optimal sigma-factor" -- but the grid-search loop
+    % left `model` sized for whichever sigma the loop tried *last* (i=100,
+    % i.e. sigma=1), not the best-fitting one `sigma` reports. Regression test:
+    % the returned model's protein-pool upper bound must equal Ptot*f*sigma*1000
+    % at the *returned* sigma, not at sigma=1 (unless they happen to coincide).
+    geckoPath = findGECKOroot;
+    adapter = ModelAdapterManager.getAdapter(fullfile(geckoPath,'test','unit_tests','ecTestGEM', 'TestGEMAdapter.m'));
+    model = getGeckoTestModel();
+    ecModel = makeEcModel(model, false, adapter);
+    ecModel = getECfromGEM(ecModel);
+    ecModel.ec.kcat(strcmp(ecModel.ec.rxns,'R3')) = 5;
+    ecModel.ec.kcat(strcmp(ecModel.ec.rxns,'R5')) = 200;
+    ecModel.ec.source(:) = {'manual'};
+    ecModel.c = double(strcmp(ecModel.rxns, 'R5'));
+    ecModel = applyKcatConstraints(ecModel);
+    ecModel = setProtPoolSize(ecModel, [], [], [], adapter);
+
+    [fittedModel, sigma] = sigmaFitter(ecModel, 'growthRate', 100, 'Ptot', 0.5, ...
+        'f', 4, 'makePlot', false, 'modelAdapter', adapter);
+
+    % This growth target does not resolve to sigma=1 on this fixture, so a model
+    % left at the loop's last trial is a real, detectable mismatch, not a
+    % coincidental pass.
+    verifyNotEqual(testCase, sigma, 1)
+
+    poolIdx = strcmp(fittedModel.rxns, 'prot_pool_exchange');
+    expected = 0.5 * 4 * sigma * 1000;
+    verifyEqual(testCase, fittedModel.ub(poolIdx), expected, 'AbsTol', 1e-9)
+end
+


### PR DESCRIPTION
## Summary
- `sigmaFitter`'s 100-point grid search loop reassigns `model` on every iteration (`model = setProtPoolSize(model, Ptot, f, sigma, modelAdapter)`), so by the time the loop ends `model`'s protein pool is sized for whichever sigma was tried *last* (`i=100`, i.e. `sigma=1`) — not the best-fitting sigma the function actually returns as `sigma`.
- The function's own docstring promises the returned `model` is "adapted to the optimal sigma-factor". Confirmed by direct execution against ecTestGEM: `sigma` came back `0.11`, but the returned model's `prot_pool_exchange` upper bound reflected `sigma=1` (`2000` instead of the correct `220 = Ptot*f*0.11*1000`).
- Found while building a cross-implementation parity scenario for `sensitivityTuning`/`sigmaFitter`/`findMaxValue`/`truncateValues` against ecTestGEM in raven-gecko-parity — geckopy's own port already carries a `MATLAB-COMPAT` note flagging this exact MATLAB behavior as a known bug it deliberately does not replicate.

## Fix
- Re-apply `setProtPoolSize` with the returned `sigma` right before returning, so the returned model actually matches the returned sigma.

## Test plan
- [x] Added `testSigmaFitterModelMatchesReturnedSigma_tc0020` to `geckoCoreFunctionTests.m`: fits sigma on a fixture where the target growth rate does not resolve to `sigma=1` (so a stale model is a real, detectable mismatch), and checks the returned model's pool bound equals `Ptot*f*sigma*1000` at the *returned* sigma.
- [x] Full suite: `runtests('geckoCoreFunctionTests.m')` — 20 passed, 0 failed.
