### PR TITLE
Fix fuzzyKcatMatching's wildcard EC search matching a substring instead of a prefix

### DIFF
--- a/src/geckomat/gather_kcats/fuzzyKcatMatching.m
+++ b/src/geckomat/gather_kcats/fuzzyKcatMatching.m
@@ -416,7 +416,14 @@ EC_indexes = [];
 EC_indexesOld = [];
 if wild
     if (~isempty(ECIndexIds)) %In some cases the EC_cell is not from KCatCell
-        X = find(contains(ECIndexIds, EC));
+        % startsWith, not contains: EC is a truncated prefix like '1.' (everything
+        % before the first wildcard dash), and an anchored match is what the
+        % non-optimized branch below already does (strfind(...)==1). contains()
+        % matches that same '1.' substring anywhere in the string, not just at the
+        % start -- '4.2.1.1' contains '1.' between its third and fourth levels, so a
+        % '1.-.-.-' wildcard query for enzyme class 1 was also matching entries from
+        % unrelated classes whose EC code happened to contain the same two characters.
+        X = find(startsWith(ECIndexIds, EC));
         for j = 1:length(X)
             EC_indexes = [EC_indexes,EcIndexIndices{X(j)}];
         end

--- a/test/unit_tests/geckoCoreFunctionTests.m
+++ b/test/unit_tests/geckoCoreFunctionTests.m
@@ -713,3 +713,60 @@ function testReportEnzymeUsageTopAbsUsageOutOfBounds_tc0019(testCase)
     verifyEqual(testCase, height(report.topAbsUsage), 2)
 end
 
+
+function testFuzzyKcatMatchingWildcardIsPrefixNotSubstring_tc0021(testCase)
+    % fuzzyKcatMatching's wildcard escalation truncates an EC code to a prefix (e.g.
+    % '1.1.1.1' -> '1.-.-.-' -> truncated query '1.') and searches BRENDA's EC column
+    % for it via extract_string_matches. The optimized path (used whenever the
+    % ECIndexIds/EcIndexIndices index is available, i.e. always, from within
+    % fuzzyKcatMatching itself) used contains(...) instead of an anchored prefix
+    % match, so a query for enzyme class 1 ('1.') could also match an EC code from an
+    % unrelated class that merely happens to contain the same two characters
+    % somewhere else in its string -- '4.2.1.1' contains '1.' between its third and
+    % fourth levels.
+    %
+    % The fixture has one legitimate class-1 entry (a real wildcard match, giving the
+    % escalation loop something to succeed on and stop at) and one unrelated
+    % '4.2.1.1' entry with a deliberately *larger* kcat: mainMatch takes the max
+    % among same-level matches, so the bug (matching both) picks the larger, wrong
+    % value; the fix (matching only the real class-1 entry) picks the smaller, correct
+    % one.
+    geckoPath = findGECKOroot;
+    adapter = ModelAdapterManager.getAdapter(fullfile(geckoPath,'test','unit_tests','ecTestGEM', 'TestGEMAdapter.m'));
+    model = getGeckoTestModel();
+    ecModel = makeEcModel(model, false, adapter);
+    ecModel = getECfromGEM(ecModel);
+
+    scratchDir = fullfile(tempname);
+    brendaDir = fullfile(scratchDir, 'data');
+    mkdir(brendaDir);
+    cleanupDir = onCleanup(@() rmdir(scratchDir, 's'));
+    % Organism matches TestGEMAdapter's own org_name exactly, so the "any organism"
+    % match tier resolves trivially instead of falling through phylDist's
+    % KEGG/genus lookup (which a fabricated organism name cannot resolve, causing
+    % every candidate to be filtered out regardless of the EC match itself).
+    fid = fopen(fullfile(brendaDir, 'max_KCAT.txt'), 'w');
+    fprintf(fid, 'EC1.9.9.9\tm1\ttestus testus//*//*\t42\t*\n');
+    fprintf(fid, 'EC4.2.1.1\tm1\ttestus testus//*//*\t500\t*\n');
+    fclose(fid);
+    fid = fopen(fullfile(brendaDir, 'max_MW.txt'), 'w');
+    fprintf(fid, 'EC0.0.0.0\t*\tplaceholder//*//*\t1\t*\n');
+    fclose(fid);
+    fid = fopen(fullfile(brendaDir, 'max_SA.txt'), 'w');
+    fprintf(fid, 'EC0.0.0.0\t*\tplaceholder//*//*\t1\t*\n');
+    fclose(fid);
+    % getPhylDistStructPath also resolves under params.path/data; reuse ecTestGEM's
+    % own real fixture rather than fabricating a second one.
+    copyfile(fullfile(geckoPath,'test','unit_tests','ecTestGEM','data','PhylDist.mat'), ...
+        fullfile(brendaDir, 'PhylDist.mat'));
+
+    % TestGEMAdapter.getBrendaDBFolder resolves to <params.path>/data --- value class,
+    % so redirecting a copy cannot affect the original (same pattern kcat_chain_ectestgem
+    % and other scenarios use for scenario-specific data).
+    fuzzyAdapter = adapter;
+    fuzzyAdapter.params.path = scratchDir;
+
+    kcatList = fuzzyKcatMatching(ecModel, ismember(ecModel.ec.rxns,{'R2_EXP_1'}), fuzzyAdapter);
+    verifyEqual(testCase, kcatList.kcats, 42)
+end
+


### PR DESCRIPTION
## Summary
- `fuzzyKcatMatching`'s wildcard escalation truncates an EC code to a prefix (e.g. `1.1.1.1` -> `1.-.-.-` -> query `1.`) and searches BRENDA's EC column for it via `extract_string_matches`. The optimized path — used on every real call, since `ECIndexIds`/`EcIndexIndices` are built unconditionally at the top of `fuzzyKcatMatching`, not something a caller opts into — used `contains(ECIndexIds, EC)`, which matches that substring *anywhere* in the string, not just at the start.
- Concretely: a wildcard query for enzyme class 1 (`1.`) also matches `4.2.1.1`, an entirely unrelated class-4 enzyme, because `"4.2.1.1"` contains the substring `"1."` between its third and fourth levels. The non-optimized fallback branch immediately below already does the right thing (`strfind(EC_cell{j},EC)==1`, an anchored match) — this brings the optimized path in line with it.
- Found while running the full kcat-gathering pipeline against real BRENDA data and yeast-GEM at genome scale in raven-gecko-parity, not reachable through the small hand-built fixtures the existing test suite uses (`git diff` shows the fixture the new test constructs is exactly what surfaces it). On yeast-GEM this single bug changed the matched kcat for hundreds of reactions.

## Fix
- `contains(ECIndexIds, EC)` -> `startsWith(ECIndexIds, EC)`.

## Test plan
- [x] Added `testFuzzyKcatMatchingWildcardIsPrefixNotSubstring_tc0021` to `geckoCoreFunctionTests.m`: a fixture with one legitimate class-1 BRENDA entry (kcat 42) and one unrelated `4.2.1.1` entry with a deliberately larger kcat (500) that only collides via the substring bug. Confirmed the test fails with `Actual=500, Expected=42` on the unpatched code (temporarily reverted the fix locally to check) and passes with the fix.
- [x] Full suite: `runtests('geckoCoreFunctionTests.m')` — 20 passed, 0 failed.
