### PR TITLE
fix: fuzzyKcatMatching's multi-EC tie-break loses its wildcard-count filter

### DIFF
--- a/src/geckomat/gather_kcats/fuzzyKcatMatching.m
+++ b/src/geckomat/gather_kcats/fuzzyKcatMatching.m
@@ -248,9 +248,14 @@ end
 if sum(origin) > 0
     %For more than one EC: Choose the maximum value among the ones with the
     %less amount of wildcards and the better origin:
-    best_pos   = (wc_num == min(wc_num));
-    new_origin = origin(best_pos);
-    best_pos   = (origin == min(new_origin(new_origin~=0)));
+    best_pos    = (wc_num == min(wc_num));
+    new_origin  = origin(best_pos);
+    best_origin = min(new_origin(new_origin~=0));
+    %Intersect with the wildcard filter above -- comparing origin==best_origin
+    %against the full (unfiltered) origin vector would let an EC with a worse
+    %(higher) wildcard count back in whenever it happens to share best_origin,
+    %defeating the wildcard-count filter entirely.
+    best_pos    = best_pos & (origin == best_origin);
     max_pos    = find(kcat == max(kcat(best_pos)));
     wc_num     = wc_num(max_pos(1));
     origin     = origin(max_pos(1));

--- a/test/unit_tests/geckoCoreFunctionTests.m
+++ b/test/unit_tests/geckoCoreFunctionTests.m
@@ -746,3 +746,70 @@ function testSigmaFitterModelMatchesReturnedSigma_tc0020(testCase)
     verifyEqual(testCase, fittedModel.ub(poolIdx), expected, 'AbsTol', 1e-9)
 end
 
+
+function testFuzzyKcatMatchingTieBreakRespectsWildcardCount_tc0022(testCase)
+    % iterativeMatch's cross-EC-token tie-break is supposed to (1) keep only the EC
+    % tokens that matched with the fewest wildcards, (2) among those keep the ones
+    % with the best (lowest) origin, then (3) take the largest kcat. Step 2's
+    % `best_pos = (origin == min(new_origin(new_origin~=0)))` re-evaluates
+    % `origin == ...` against the *full*, unfiltered origin vector instead of the
+    % wildcard-filtered subset from step 1 -- so any EC token that matched at a
+    % *worse* (higher) wildcard level, but happens to share the same origin value,
+    % is let back in. Step 3 then maximises kcat across that too-permissive set, so
+    % a less-specific, more-wildcarded match can silently win over a fully-specific
+    % one whenever it happens to report a bigger kcat.
+    %
+    % The fixture gives R2_EXP_1 two EC tokens: '9.9.9.1' matches BRENDA directly
+    % (0 wildcards, kcat 42); '9.9.8.-' only matches after escalating twice more (2
+    % wildcards, kcat 500) -- both land on origin 3 (organism matches, substrate
+    % deliberately does not, so origin 1/2 are skipped). The correct answer is the
+    % 0-wildcard match (42); the bug picks the 2-wildcard one (500) because both
+    % share origin 3.
+    %
+    % Found while running the kcat-gathering pipeline against real BRENDA data and
+    % yeast-GEM at genome scale in raven-gecko-parity: ~119 reactions got a kcat
+    % that genuinely differed (not just missing) between the MATLAB and Python
+    % implementations even after two other confirmed bugs were fixed; this
+    % tie-break scoping bug, triggered whenever a multi-EC-code reaction's tokens
+    % match at different wildcard levels but the same origin, accounts for at
+    % least some of those.
+    geckoPath = findGECKOroot;
+    adapter = ModelAdapterManager.getAdapter(fullfile(geckoPath,'test','unit_tests','ecTestGEM', 'TestGEMAdapter.m'));
+    model = getGeckoTestModel();
+    ecModel = makeEcModel(model, false, adapter);
+    ecModel = getECfromGEM(ecModel);
+    ecModel.ec.eccodes{strcmp(ecModel.ec.rxns, 'R2_EXP_1')} = '9.9.9.1;9.9.8.-';
+
+    scratchDir = fullfile(tempname);
+    brendaDir = fullfile(scratchDir, 'data');
+    mkdir(brendaDir);
+    cleanupDir = onCleanup(@() rmdir(scratchDir, 's'));
+    % Substrate deliberately does not match the model's actual substrate (m1), so
+    % origin 1/2 (which require a substrate match) are skipped and both tokens are
+    % forced to resolve at origin 3, isolating the wildcard-count tie-break.
+    fid = fopen(fullfile(brendaDir, 'max_KCAT.txt'), 'w');
+    fprintf(fid, 'EC9.9.9.1\tunrelatedsubstrate\ttestus testus//*//*\t42\t*\n');
+    fprintf(fid, 'EC9.9.7.5\tunrelatedsubstrate\ttestus testus//*//*\t500\t*\n');
+    fclose(fid);
+    fid = fopen(fullfile(brendaDir, 'max_MW.txt'), 'w');
+    fprintf(fid, 'EC0.0.0.0\t*\tplaceholder//*//*\t1\t*\n');
+    fclose(fid);
+    fid = fopen(fullfile(brendaDir, 'max_SA.txt'), 'w');
+    fprintf(fid, 'EC0.0.0.0\t*\tplaceholder//*//*\t1\t*\n');
+    fclose(fid);
+    % getPhylDistStructPath also resolves under params.path/data; reuse ecTestGEM's
+    % own real fixture rather than fabricating a second one.
+    copyfile(fullfile(geckoPath,'test','unit_tests','ecTestGEM','data','PhylDist.mat'), ...
+        fullfile(brendaDir, 'PhylDist.mat'));
+
+    % TestGEMAdapter.getBrendaDBFolder resolves to <params.path>/data --- value class,
+    % so redirecting a copy cannot affect the original (same pattern kcat_chain_ectestgem
+    % and other scenarios use for scenario-specific data).
+    fuzzyAdapter = adapter;
+    fuzzyAdapter.params.path = scratchDir;
+
+    kcatList = fuzzyKcatMatching(ecModel, ismember(ecModel.ec.rxns,{'R2_EXP_1'}), fuzzyAdapter);
+    verifyEqual(testCase, kcatList.kcats, 42)
+    verifyEqual(testCase, kcatList.wildcardLvl, 0)
+end
+


### PR DESCRIPTION
## Summary

- `iterativeMatch`'s cross-EC-token tie-break (used when a reaction's EC annotation has more than one `;`-separated code) is supposed to narrow candidates in three steps: fewest wildcards, then best (lowest) origin among those, then largest kcat among those. The middle step recomputed its filter against the *full*, unfiltered `origin` vector instead of intersecting with the wildcard-count mask from the first step, so an EC token that only matched after escalating to a worse (higher) wildcard level — but happened to land on the same origin value as the best token — was let back into the final max-kcat comparison. A less specific, more heavily wildcarded match could then silently outrank a fully specific one whenever it happened to report a bigger kcat.
- Fix: intersect the origin filter with the wildcard-count mask (`best_pos & (origin == best_origin)`) instead of recomputing it from scratch.

## Context

Found while running the kcat-gathering pipeline against real BRENDA data and yeast-GEM at genome scale in [raven-gecko-parity](https://github.com/SysBioChalmers/raven-gecko-parity)'s `ec_model_full_yeastgem` scenario. After two other confirmed bugs were fixed (#433, this branch's parent PR fixing the wildcard substring-vs-prefix match), ~119 of 4671 reactions still got a kcat value that genuinely differed (not just missing) between GECKO (MATLAB) and geckopy (Python) on the same real BRENDA snapshot.

Tracing a representative sample (`r_0021`, `r_0022`, `r_0062_EXP_1`, `r_0064_EXP_1`) against geckopy's independently-implemented port (`fuzzy_kcat_matching`) confirmed each is a multi-EC-code reaction where different EC tokens match BRENDA at different wildcard levels but the same origin — exactly this bug's trigger condition. geckopy's tie-break correctly scopes the origin filter to the wildcard-minimal subset and picks the more specific match; MATLAB's did not, and picked the less specific one. Both implementations' organism-filtering logic had already been checked and ruled out as faithful ports of each other, narrowing the search to the tie-break / multi-EC-token logic instead — which is where this turned out to live.

## Test plan

- [x] Added `testFuzzyKcatMatchingTieBreakRespectsWildcardCount_tc0022` to `test/unit_tests/geckoCoreFunctionTests.m`: an isolated fixture where reaction `R2_EXP_1` is given two EC tokens, one matching BRENDA directly (0 wildcards, kcat 42) and one only matching after escalating twice more (2 wildcards, kcat 500), both resolving to the same origin. Verified the test fails (returns 500) against the pre-fix code and passes (returns 42, wildcard level 0) against the fix.
- [x] `runtests('geckoCoreFunctionTests.m')`: 21/21 passing.
