### PR TITLE
Fix writeOpenKineticsPredictorInput reaction-subset indexing

### DIFF
--- a/src/geckomat/gather_kcats/writeOpenKineticsPredictorInput.m
+++ b/src/geckomat/gather_kcats/writeOpenKineticsPredictorInput.m
@@ -150,8 +150,10 @@ clearedS = reducedS(:, origRxnIdxs);
 % Find all substrates (negative stoichiometry)
 [substrateIdxs, reactionIdxs] = find(clearedS < 0);
 
-% Find proteins catalyzing each reaction
-[proteinIdxs, rxnEnzIdxs] = find(model.ec.rxnEnzMat(reactionIdxs,:)');
+% Find proteins catalyzing each reaction. reactionIdxs indexes clearedS's
+% columns, i.e. positions within the requested ecRxnsIdx subset -- map back
+% through ecRxnsIdx to the absolute model.ec.rxnEnzMat row before indexing it.
+[proteinIdxs, rxnEnzIdxs] = find(model.ec.rxnEnzMat(ecRxnsIdx(reactionIdxs),:)');
 
 %% Build output: sequence and SMILES
 sequences = model.ec.sequence(proteinIdxs);

--- a/test/unit_tests/geckoCoreFunctionTests.m
+++ b/test/unit_tests/geckoCoreFunctionTests.m
@@ -870,3 +870,55 @@ function testFuzzyKcatMatchingTieBreakRespectsWildcardCount_tc0022(testCase)
     verifyEqual(testCase, kcatList.wildcardLvl, 0)
 end
 
+
+function testWriteOpenKineticsPredictorInputReactionSubsetIndex_tc0023(testCase)
+    % writeOpenKineticsPredictorInput restricts its work to the requested ecRxns
+    % subset by first building clearedS = reducedS(:, origRxnIdxs), then finding
+    % substrates with reactionIdxs = find(clearedS < 0) -- reactionIdxs is a
+    % *column position within that subset* (1..numel(ecRxnsIdx)), not an absolute
+    % index into model.ec.rxns. The next line indexed model.ec.rxnEnzMat directly
+    % with reactionIdxs, silently picking the wrong ec.rxns row (or the wrong
+    % protein set entirely) whenever the requested subset excludes any earlier
+    % ec.rxns entry -- which shifts every later entry's subset-position below its
+    % absolute position.
+    %
+    % ecTestGEM's R2 has two isozymes (G1+G2 complex, and G3 alone), each
+    % expanded to its own ec.rxns row (R2_EXP_1, R2_EXP_2) plus a reverse copy
+    % (R2_REV_EXP_1, R2_REV_EXP_2) -- ec.rxns order is [R2_EXP_1, R2_EXP_2,
+    % R2_REV_EXP_1, R2_REV_EXP_2, R3, R5]. Requesting ecRxns={R2_EXP_1, R2_EXP_2,
+    % R3} excludes the two REV entries in between, so R3's subset position (3)
+    % no longer equals its absolute ec.rxns position (5): the bug reads
+    % rxnEnzMat row 3 (R2_REV_EXP_1's genes, G1+G2) instead of row 5 (R3's own
+    % gene, G4), so R3/G4 never appears in the output and G1/G2 appear twice.
+    geckoPath = findGECKOroot;
+    adapter = ModelAdapterManager.getAdapter(fullfile(geckoPath,'test','unit_tests','ecTestGEM', 'TestGEMAdapter.m'));
+    model = getGeckoTestModel();
+    ecModel = makeEcModel(model, false, adapter);
+    ecModel = getECfromGEM(ecModel);
+
+    % Self-contained SMILES: only m1c (R2/R3's shared substrate) needs one for
+    % this test, so skip findMetSmiles/PubChem entirely.
+    ecModel.metSmiles = repmat({''}, numel(ecModel.mets), 1);
+    ecModel.metSmiles(strcmp(ecModel.mets,'m1c')) = {'C(C1C)O'};
+
+    scratchDir = fullfile(tempname);
+    mkdir(fullfile(scratchDir,'data'));
+    cleanupDir = onCleanup(@() rmdir(scratchDir, 's'));
+    % writeOpenKineticsPredictorInput resolves its own output path through
+    % params.path/data --- value-class copy, same redirect pattern as every
+    % other scenario/test in this file that writes a file.
+    writeAdapter = adapter;
+    writeAdapter.params.path = scratchDir;
+
+    writeOpenKineticsPredictorInput(ecModel, 'ecRxns', ismember(ecModel.ec.rxns, {'R2_EXP_1','R2_EXP_2','R3'}), ...
+        'modelAdapter', writeAdapter, 'onlyWithSmiles', true, 'overwrite', true);
+
+    fID = fopen(fullfile(scratchDir,'data','OKP.csv'));
+    raw = textscan(fID, '%s %s', 'Delimiter', ',', 'HeaderLines', 1);
+    fclose(fID);
+    rows = sort(strcat(raw{1}, ',', raw{2}));
+
+    expected = sort({'MRAL,C(C1C)O'; 'MNTD,C(C1C)O'; 'MSYN,C(C1C)O'; 'MDFM,C(C1C)O'});
+    verifyEqual(testCase, rows, expected)
+end
+


### PR DESCRIPTION
`writeOpenKineticsPredictorInput.m` restricts its work to the requested `ecRxns` subset by building `clearedS = reducedS(:, origRxnIdxs)`, then `reactionIdxs = find(clearedS < 0)`. `reactionIdxs` is a **column position within that subset** (`1..numel(ecRxnsIdx)`), not an absolute index into `model.ec.rxns`. It was then used directly to index `model.ec.rxnEnzMat`, which is indexed by absolute `ec.rxns` position (`1..numel(model.ec.rxns)`).

The two only coincide when the subset is "everything, in `ec.rxns` order." Any subset that excludes an earlier `ec.rxns` entry shifts every later entry's subset position below its absolute position, so the wrong `rxnEnzMat` row — wrong protein set, or none at all — gets read for it.

Concretely, on GECKO's own `ecTestGEM` unit-test model: `ec.rxns` order is `[R2_EXP_1, R2_EXP_2, R2_REV_EXP_1, R2_REV_EXP_2, R3, R5]`. Requesting `ecRxns = {R2_EXP_1, R2_EXP_2, R3}` (a perfectly ordinary partial selection — e.g. "just my forward reactions with EC codes") excludes the two `REV` entries in between, so `R3`'s subset position (3) no longer equals its absolute `ec.rxns` position (5). The bug reads `rxnEnzMat` row 3 (`R2_REV_EXP_1`'s genes) instead of row 5 (`R3`'s own gene) — `R3`'s enzyme never appears in the OKP input at all, and `R2_REV_EXP_1`'s genes appear as a spurious duplicate instead.

Found while building a behavioural-parity scenario for this function against geckopy's `build_okp_input_csv` in [raven-gecko-parity](https://github.com/SysBioChalmers/raven-gecko-parity) — geckopy's equivalent does not have this bug (confirmed by direct execution on the same fixture/subset).

Fixed by mapping `reactionIdxs` back through `ecRxnsIdx` before indexing `rxnEnzMat`. Added `testWriteOpenKineticsPredictorInputReactionSubsetIndex_tc0023`, verified to fail with the exact predicted wrong output (missing `R3`/`G4`, duplicated `G1`/`G2`) on the unpatched function and pass once fixed. Full `geckoCoreFunctionTests` suite: 23 passed, 0 failed.
