### PR TITLE
Add getEnzymeBottlenecks, ranking enzymes by shadow price

### DIFF
--- a/src/geckomat/utilities/getEnzymeBottlenecks.m
+++ b/src/geckomat/utilities/getEnzymeBottlenecks.m
@@ -1,0 +1,79 @@
+function bottlenecks = getEnzymeBottlenecks(model, varargin)
+% getEnzymeBottlenecks  Top-N enzymes limiting the current objective.
+%
+% Solves the model and ranks every enzyme by the absolute shadow price of
+% its prot_<id> mass-balance constraint --- the enzymes whose extra
+% availability would help the objective the most.
+%
+% Parameters
+% ----------
+% model : struct
+%     a full ecModel in GECKO 3 format (with ecModel.ec structure). Not
+%     supported for gecko-light models, which have no per-enzyme
+%     prot_<id> / usage_prot_<id> machinery.
+%
+% Name-Value Arguments
+% --------------------
+% top : double
+%     number of enzymes to return (default 10).
+%
+% Returns
+% -------
+% bottlenecks : table
+%     one row per returned enzyme, sorted by descending absolute shadow
+%     price, with columns uniprot, gene, shadowPrice, flux, capUsage
+%     (abs(flux)/upperBound, NaN if upperBound is 0) and upperBound.
+%
+% Examples
+% --------
+%     bottlenecks = getEnzymeBottlenecks(ecModel);
+%     bottlenecks = getEnzymeBottlenecks(ecModel, 'top', 5);
+%
+% Notes
+% -----
+% Ported from geckopy's get_enzyme_bottlenecks (utilities/bottlenecks.py),
+% itself ported from the legacy geckopy package (Carrasco et al., 2023,
+% https://doi.org/10.1128/spectrum.01705-23), geckopy/flux_analysis.py:275-281
+% (get_protein_bottlenecks).
+
+p = parseGECKOargs(varargin, {'top', []});
+top = p.top;
+if isempty(top)
+    top = 10;
+end
+
+if isfield(model.ec, 'geckoLight') && model.ec.geckoLight
+    error(['getEnzymeBottlenecks requires a full ecModel, not gecko-light: ' ...
+        'light models have no per-enzyme prot_<id> / usage_prot_<id> machinery.'])
+end
+
+sol = solveLP(model);
+if sol.stat ~= 1
+    error('getEnzymeBottlenecks: solver status %d; cannot rank bottlenecks.', sol.stat)
+end
+
+uniprot = model.ec.enzymes(:);
+gene    = model.ec.genes(:);
+
+protMets  = strcat('prot_', uniprot);
+[found, metIdx] = ismember(protMets, model.mets);
+if ~all(found)
+    error('Cannot find prot_<id> metabolites for all enzymes. This is done by makeEcModel.')
+end
+usageRxns = strcat('usage_prot_', uniprot);
+[found, rxnIdx] = ismember(usageRxns, model.rxns);
+if ~all(found)
+    error('Usage reactions are not defined for all enzymes. This is done by makeEcModel.')
+end
+
+shadowPrice = sol.sPrice(metIdx);
+flux        = sol.x(rxnIdx);
+upperBound  = model.ub(rxnIdx);
+capUsage    = abs(flux) ./ upperBound;
+capUsage(upperBound == 0) = NaN;
+
+bottlenecks = table(uniprot, gene, shadowPrice, flux, capUsage, upperBound);
+[~, order] = sort(abs(bottlenecks.shadowPrice), 'descend');
+bottlenecks = bottlenecks(order, :);
+bottlenecks = bottlenecks(1:min(top, height(bottlenecks)), :);
+end

--- a/test/unit_tests/geckoCoreFunctionTests.m
+++ b/test/unit_tests/geckoCoreFunctionTests.m
@@ -922,3 +922,38 @@ function testWriteOpenKineticsPredictorInputReactionSubsetIndex_tc0023(testCase)
     verifyEqual(testCase, rows, expected)
 end
 
+
+function testGetEnzymeBottlenecksRanksByShadowPrice_tc0024(testCase)
+    % getEnzymeBottlenecks: solves the model, ranks enzymes by |shadow price| of
+    % their prot_<id> mass-balance constraint, returns the top N. Cross-verified
+    % against geckopy's get_enzyme_bottlenecks on the identical fixture (uniform
+    % kcat=10 across every ec.rxns row, prot pool sized via Ptot=0.5/f=0.5/
+    % sigma=0.5): both sides agree exactly on the objective (90), every column
+    % (shadowPrice=-0.72 for all five enzymes, flux/capUsage/upperBound), and the
+    % top-3 selection (P1/P2/P3, tied at -0.72, in original ec.enzymes order).
+    geckoPath = findGECKOroot;
+    adapter = ModelAdapterManager.getAdapter(fullfile(geckoPath,'test','unit_tests','ecTestGEM', 'TestGEMAdapter.m'));
+    model = getGeckoTestModel();
+    ecModel = makeEcModel(model, false, adapter);
+    ecModel = getECfromGEM(ecModel);
+    ecModel.ec.kcat(:) = 10;
+    ecModel.ec.source(:) = {'manual'};
+    ecModel = applyKcatConstraints(ecModel);
+    ecModel = setProtPoolSize(ecModel, 0.5, 0.5, 0.5, adapter);
+
+    sol = solveLP(ecModel);
+    verifyEqual(testCase, sol.stat, 1)
+    verifyEqual(testCase, sol.f, 90, 'AbsTol', 1e-9)
+
+    bottlenecks = getEnzymeBottlenecks(ecModel);
+    verifyEqual(testCase, height(bottlenecks), 5)
+    verifyEqual(testCase, bottlenecks.shadowPrice, repmat(-0.72, 5, 1), 'AbsTol', 1e-9)
+    [~, order] = ismember({'P1','P2','P3','P4','P5'}, bottlenecks.uniprot);
+    verifyEqual(testCase, bottlenecks.flux(order), [0;0;0;0;125], 'AbsTol', 1e-9)
+    verifyEqual(testCase, bottlenecks.capUsage(order), [0;0;0;0;0.125], 'AbsTol', 1e-9)
+    verifyEqual(testCase, bottlenecks.upperBound(order), repmat(1000, 5, 1), 'AbsTol', 1e-9)
+
+    top3 = getEnzymeBottlenecks(ecModel, 'top', 3);
+    verifyEqual(testCase, top3.uniprot, {'P1';'P2';'P3'})
+end
+


### PR DESCRIPTION
Ports geckopy's `get_enzyme_bottlenecks` (`utilities/bottlenecks.py`) to MATLAB — itself ported from the legacy geckopy package (Carrasco et al., 2023, https://doi.org/10.1128/spectrum.01705-23, `geckopy/flux_analysis.py:275-281`, `get_protein_bottlenecks`). Tracked as [SysBioChalmers/raven-gecko-parity#22](https://github.com/SysBioChalmers/raven-gecko-parity/issues/22).

## What it does

Solves the model and ranks every enzyme by the absolute shadow price of its `prot_<id>` mass-balance constraint — the enzymes whose extra availability would help the objective the most. Returns the top N (default 10) with `gene`, `shadowPrice`, `flux`, `capUsage` (`|flux|/upperBound`), and `upperBound`.

Both sides already share the `prot_<id>` / `usage_prot_<id>` naming convention (same as `constrainEnzConcs.m`'s own indexing pattern), so this reads directly off `solveLP`'s existing output — `sol.x` for flux, `sol.sPrice` for shadow prices, `model.ub` for upper bound — no per-enzyme proxy object needed (that's geckopy's `Enzyme` class, a language-idiom convenience with no MATLAB equivalent, and correctly out of scope here).

## Verification

Cross-checked against geckopy's `get_enzyme_bottlenecks` on an identical ecTestGEM-based fixture (uniform `kcat=10` across every `ec.rxns` row, protein pool sized via `Ptot=0.5/f=0.5/sigma=0.5`): exact match on the objective value (90), every returned enzyme's `shadowPrice`/`flux`/`capUsage`/`upperBound`, and the top-3 selection. Added `testGetEnzymeBottlenecksRanksByShadowPrice_tc0024` to `geckoCoreFunctionTests.m` asserting the same. Full suite: 24 passed, 0 failed.
