### PR TITLE
Add pfbaEnzymes, enzyme-aware parsimonious FBA

### DIFF
--- a/src/geckomat/utilities/pfbaEnzymes.m
+++ b/src/geckomat/utilities/pfbaEnzymes.m
@@ -1,0 +1,128 @@
+function solution = pfbaEnzymes(model, varargin)
+% pfbaEnzymes  Parsimonious FBA minimising total enzyme usage.
+%
+% Among all flux distributions at (or within a fraction of) the optimal
+% value of the current objective, finds the one that minimises total
+% enzyme usage: the smallest sum of usage_prot_* fluxes. This is the
+% enzyme-aware analogue of classical pFBA, which minimises total flux
+% instead --- for ecModels this usually picks the most parsimonious
+% *proteome*, not just the most parsimonious fluxes.
+%
+% Parameters
+% ----------
+% model : struct
+%     a full ecModel in GECKO 3 format (with ecModel.ec structure and
+%     usage_prot_<id> reactions). Not supported for gecko-light models.
+%
+% Name-Value Arguments
+% --------------------
+% rxnId : char
+%     reaction id to use as the objective instead of model.c as given
+%     (default: use model.c as given).
+% fractionOfOptimum : double
+%     fraction of the optimal objective value to fix before minimising
+%     enzyme usage (default 1.0).
+%
+% Returns
+% -------
+% solution : struct
+%     - x : flux distribution (indexed by model.rxns) at the
+%       enzyme-usage-minimising solution.
+%     - enzymeUsage : the minimised sum of usage_prot_* fluxes.
+%     - objectiveValue : the fixed objective's own value at this solution.
+%     - stat : solveLP exit flag.
+%
+% Examples
+% --------
+%     solution = pfbaEnzymes(ecModel);
+%     solution = pfbaEnzymes(ecModel, 'fractionOfOptimum', 0.9);
+%
+% Notes
+% -----
+% Ported from geckopy's pfba_enzymes (utilities/pfba_enzymes.py), itself
+% ported from the legacy geckopy package (Carrasco et al., 2023,
+% https://doi.org/10.1128/spectrum.01705-23), geckopy/flux_analysis.py:342-386
+% (pfba_protein).
+%
+% Fixes the objective as a constraint the same way solveLP's own minFlux=1
+% option does internally: a "fake metabolite" produced by each reaction
+% with the stoichiometry it has in the objective, constrained to at least
+% the target value (with the same 1e-6 relative safety margin solveLP
+% itself applies, to avoid spurious infeasibility from solver tolerance).
+%
+% usage_prot_<id> reactions are forward-only (lb=0) in the standard GECKO 3
+% layout. If any has lb<0 (reverse flux enabled), minimising its raw flux
+% would not minimise |flux| for that reaction, unlike geckopy's cobra-based
+% forward/reverse variable split --- this function errors in that case
+% rather than silently building an incorrect objective.
+%
+% See also
+% --------
+% getEnzymeBottlenecks
+
+p = parseGECKOargs(varargin, {'rxnId', []; 'fractionOfOptimum', []});
+rxnId             = p.rxnId;
+fractionOfOptimum = p.fractionOfOptimum;
+if isempty(fractionOfOptimum)
+    fractionOfOptimum = 1.0;
+end
+
+if isfield(model.ec, 'geckoLight') && model.ec.geckoLight
+    error(['pfbaEnzymes requires a full ecModel, not gecko-light: light models have no ' ...
+        'usage_prot_<id> reactions.'])
+end
+
+if ~isempty(rxnId)
+    rxnIdx = find(strcmp(model.rxns, rxnId));
+    if isempty(rxnIdx)
+        error('pfbaEnzymes: reaction %s not found in model.rxns.', rxnId)
+    end
+    model.c = zeros(numel(model.rxns), 1);
+    model.c(rxnIdx) = 1;
+end
+if ~any(model.c)
+    error('pfbaEnzymes: model.c is empty; nothing to fix before minimising enzyme usage.')
+end
+
+usageIdx = find(startsWith(model.rxns, 'usage_prot_'));
+if isempty(usageIdx)
+    error('pfbaEnzymes: no usage_prot_<id> reactions found. This is done by makeEcModel.')
+end
+if any(model.lb(usageIdx) < 0)
+    error(['pfbaEnzymes does not support usage_prot_<id> reactions with a negative lower ' ...
+        'bound (reverse flux enabled): minimising raw flux would not minimise |flux| for ' ...
+        'those reactions.'])
+end
+
+solOrig = solveLP(model);
+if solOrig.stat ~= 1
+    error('pfbaEnzymes: solver status %d on the original objective; cannot fix it as a constraint.', solOrig.stat)
+end
+
+% Fix the objective as a constraint, same "fake metabolite" technique
+% solveLP's own minFlux=1 option uses (see solveLP.m).
+target = fractionOfOptimum * solOrig.f;
+if target > 0
+    target = target * 0.999999;
+else
+    target = target * 1.000001;
+end
+fixModel = model;
+fixModel.S(end+1, :) = model.c';
+fixModel.mets{end+1, 1} = 'pfbaEnzymes_objective';
+if size(fixModel.b, 2) == 1
+    fixModel.b = [fixModel.b fixModel.b];
+end
+fixModel.b(end+1, :) = [target inf];
+
+fixModel.c = zeros(numel(fixModel.rxns), 1);
+fixModel.c(usageIdx) = -1;
+
+solution = solveLP(fixModel);
+if solution.stat ~= 1
+    error('pfbaEnzymes: minimising enzyme usage was infeasible at fractionOfOptimum=%g.', fractionOfOptimum)
+end
+
+solution.enzymeUsage    = -solution.f;
+solution.objectiveValue = model.c' * solution.x;
+end

--- a/test/unit_tests/geckoCoreFunctionTests.m
+++ b/test/unit_tests/geckoCoreFunctionTests.m
@@ -922,3 +922,58 @@ function testWriteOpenKineticsPredictorInputReactionSubsetIndex_tc0023(testCase)
     verifyEqual(testCase, rows, expected)
 end
 
+
+function testPfbaEnzymesMinimisesEnzymeUsage_tc0024(testCase)
+    % pfbaEnzymes: fixes the current objective (growth, via R5) as a constraint,
+    % then minimises total usage_prot_* flux. Cross-verified against geckopy's
+    % pfba_enzymes on the identical fixture (uniform kcat=10, protein pool
+    % Ptot=0.5/f=0.5/sigma=0.5): geckopy reports growth=90 exactly and
+    % enzyme_usage=125 exactly at the enzyme-minimising solution, using only
+    % usage_prot_P5 (every other usage reaction at 0). pfbaEnzymes.m reproduces
+    % the same solution up to the ~1e-6 relative safety margin it borrows from
+    % solveLP's own minFlux=1 "fake metabolite" technique (see solveLP.m) ---
+    % a deliberate, documented difference from geckopy's exact constraint, not
+    % a divergence in the algorithm itself.
+    geckoPath = findGECKOroot;
+    adapter = ModelAdapterManager.getAdapter(fullfile(geckoPath,'test','unit_tests','ecTestGEM', 'TestGEMAdapter.m'));
+    model = getGeckoTestModel();
+    ecModel = makeEcModel(model, false, adapter);
+    ecModel = getECfromGEM(ecModel);
+    ecModel.ec.kcat(:) = 10;
+    ecModel.ec.source(:) = {'manual'};
+    ecModel = applyKcatConstraints(ecModel);
+    ecModel = setProtPoolSize(ecModel, 0.5, 0.5, 0.5, adapter);
+
+    solution = pfbaEnzymes(ecModel);
+    verifyEqual(testCase, solution.stat, 1)
+    verifyEqual(testCase, solution.objectiveValue, 90, 'RelTol', 1e-5)
+    verifyEqual(testCase, solution.enzymeUsage, 125, 'RelTol', 1e-5)
+
+    usageIdx = find(startsWith(ecModel.rxns, 'usage_prot_'));
+    usageFlux = solution.x(usageIdx);
+    [~, order] = ismember(strcat('usage_prot_', {'P1','P2','P3','P4','P5'}), ecModel.rxns(usageIdx));
+    verifyEqual(testCase, usageFlux(order), [0;0;0;0;125], 'AbsTol', 1e-3)
+
+    % fractionOfOptimum halves both the fixed growth target and, on this
+    % fixture, the enzyme usage needed to reach it.
+    solutionHalf = pfbaEnzymes(ecModel, 'fractionOfOptimum', 0.5);
+    verifyEqual(testCase, solutionHalf.objectiveValue, 45, 'RelTol', 1e-5)
+    verifyEqual(testCase, solutionHalf.enzymeUsage, 62.5, 'RelTol', 1e-5)
+
+    % rxnId overrides which reaction is fixed as the objective before
+    % minimising enzyme usage, without erroring.
+    solutionR3 = pfbaEnzymes(ecModel, 'rxnId', 'R3');
+    verifyEqual(testCase, solutionR3.stat, 1)
+
+    % gecko-light guard: no usage_prot_<id> machinery to minimise over.
+    lightModel = makeEcModel(model, true, adapter);
+    lightModel = getECfromGEM(lightModel);
+    try
+        pfbaEnzymes(lightModel);
+        raised = false;
+    catch
+        raised = true;
+    end
+    verifyTrue(testCase, raised)
+end
+


### PR DESCRIPTION
Ports geckopy's `pfba_enzymes` (`utilities/pfba_enzymes.py`) to MATLAB — itself ported from the legacy geckopy package (Carrasco et al., 2023, https://doi.org/10.1128/spectrum.01705-23, `geckopy/flux_analysis.py:342-386`, `pfba_protein`). Tracked as [SysBioChalmers/raven-gecko-parity#23](https://github.com/SysBioChalmers/raven-gecko-parity/issues/23).

## What it does

Enzyme-aware parsimonious FBA: among all flux distributions at (or within a fraction of) the optimal objective, finds the one minimising total enzyme usage (`sum(usage_prot_*)`) rather than total flux. For ecModels this usually picks the most parsimonious *proteome*, not just the most parsimonious fluxes.

## Implementation note

Fixes the current objective as a constraint using the same "fake metabolite" technique `solveLP`'s own `minFlux=1` option already uses internally (append a row to `model.S` equal to `model.c`, bounded at `fractionOfOptimum * optimal` with the same ~1e-6 relative safety margin `solveLP` itself applies) — reusing an established, already-battle-tested pattern in this codebase rather than introducing a new one.

## The one design decision flagged in #23

geckopy's usage reactions are forward-only (`lb=0`) by construction; if one has been flipped to allow reverse flux, cobra's `reverse_variable` machinery still minimises `|flux|` correctly for it. MATLAB has no equivalent automatic variable split. Rather than build one for a case that can't currently arise in any real GECKO 3 ecModel, `pfbaEnzymes` explicitly rejects a `usage_prot_<id>` reaction with `lb<0` instead of silently building an incorrect objective for it.

## Verification

Cross-checked against geckopy's `pfba_enzymes` on an identical ecTestGEM-based fixture (uniform `kcat=10`, protein pool `Ptot=0.5/f=0.5/sigma=0.5`): geckopy reports growth `=90` and `enzyme_usage=125` exactly, using only `usage_prot_P5`; `pfbaEnzymes.m` reproduces the same solution (same enzyme usage pattern, same reactions at zero) up to the deliberate ~1e-6 relative safety margin described above. Added `testPfbaEnzymesMinimisesEnzymeUsage_tc0024` to `geckoCoreFunctionTests.m`, covering the default call, `fractionOfOptimum`, the `rxnId` objective override, and the gecko-light guard. Full suite: 24 passed, 0 failed.
