### PR TITLE
Add OpenKineticsPredictor REST client (submit/fetch)

### DIFF
--- a/src/geckomat/gather_kcats/fetchOpenKineticsPredictor.m
+++ b/src/geckomat/gather_kcats/fetchOpenKineticsPredictor.m
@@ -1,0 +1,157 @@
+function [done, kcatList] = fetchOpenKineticsPredictor(model, varargin)
+% fetchOpenKineticsPredictor  Fetch and parse an OpenKineticsPredictor job.
+%
+% Checks the status of an OpenKineticsPredictor job and, when it has
+% finished, downloads the result to data/OKP_output.csv and parses it (via
+% readOpenKineticsPredictorOutput) into a kcatList consumable by
+% selectKcatValue.
+%
+% The API key (only needed when useStored=false) is resolved from the
+% OKP_API_KEY environment variable or data/okpApiKey.txt; see
+% submitOpenKineticsPredictor for how to obtain and store a key.
+%
+% Parameters
+% ----------
+% model : struct
+%     ecModel in GECKO 3 format (with ecModel.ec structure; model.metSmiles
+%     is required to map results back).
+%
+% Name-Value Arguments
+% --------------------
+% useStored : logical
+%     if true, skip the API entirely and parse the already-downloaded
+%     data/OKP_output.csv. If false, query the API (default false).
+% jobId : char
+%     OKP job id (default: read from data/OKP_job.txt, written by
+%     submitOpenKineticsPredictor).
+% wait : logical
+%     if true, poll until the job finishes; if false, report once and
+%     return (default false).
+% pollInterval : double
+%     seconds between polls when wait=true (default 30).
+% modelAdapter : ModelAdapter
+%     a loaded model adapter (default: the current default model adapter).
+%
+% Returns
+% -------
+% done : logical
+%     true if a result was obtained (downloaded or loaded from disk).
+% kcatList : struct
+%     structure with kcat values (empty when not done); see
+%     readOpenKineticsPredictorOutput for its fields (source, rxns, genes,
+%     substrates, kcats, kcatSource).
+%
+% Examples
+% --------
+%     [done, kcatList] = fetchOpenKineticsPredictor(model);                        % check once
+%     [done, kcatList] = fetchOpenKineticsPredictor(model, 'wait', true);          % poll
+%     [done, kcatList] = fetchOpenKineticsPredictor(model, 'useStored', true);     % parse stored file
+%
+% See also
+% --------
+% submitOpenKineticsPredictor, readOpenKineticsPredictorOutput
+
+p = parseGECKOargs(varargin, { ...
+    'useStored',    []; ...
+    'jobId',        []; ...
+    'wait',         []; ...
+    'pollInterval', []; ...
+    'modelAdapter', []});
+useStored    = p.useStored;
+jobId        = p.jobId;
+wait         = p.wait;
+pollInterval = p.pollInterval;
+modelAdapter = p.modelAdapter;
+
+if isempty(useStored); useStored = false; end
+if isempty(modelAdapter)
+    modelAdapter = ModelAdapterManager.getDefault();
+    if isempty(modelAdapter)
+        error('Either send in a modelAdapter or set the default model adapter in the ModelAdapterManager.')
+    end
+end
+params = modelAdapter.params;
+if isempty(wait); wait = false; end
+if isempty(pollInterval); pollInterval = 30; end
+
+outFile = fullfile(params.path,'data','OKP_output.csv');
+
+%% Stored-result mode: parse the saved file, no API call
+if useStored
+    if ~exist(outFile,'file')
+        error('useStored=true but no stored result found at %s. Run fetchOpenKineticsPredictor with useStored=false first.', outFile);
+    end
+    kcatList = readOpenKineticsPredictorOutput(model, 'outFile', outFile, 'modelAdapter', modelAdapter);
+    done = true;
+    return
+end
+
+%% API mode
+apiKey = resolveOkpApiKey('', params.path);
+
+if isempty(jobId)
+    jobId = readJobIdFromMeta(fullfile(params.path,'data','OKP_job.txt'));
+end
+
+base = 'https://predictor.openkinetics.org/api/v1';
+opts = weboptions('HeaderFields', {'Authorization', ['Bearer ' apiKey]}, ...
+                   'Timeout', 60, 'ContentType', 'json');
+
+while true
+    statusResp = webread([base '/status/' jobId '/'], opts);
+    state = lower(string(statusResp.status));
+
+    switch state
+        case "completed"
+            csvText = webread([base '/result/' jobId '/'], ...
+                weboptions('HeaderFields', {'Authorization', ['Bearer ' apiKey]}, ...
+                           'Timeout', 120, 'ContentType', 'text'));
+            fID = fopen(outFile,'w');
+            fwrite(fID, csvText);
+            fclose(fID);
+            fprintf('OKP job %s completed; result stored at %s\n', jobId, outFile);
+            kcatList = readOpenKineticsPredictorOutput(model, 'outFile', outFile, 'modelAdapter', modelAdapter);
+            done = true;
+            return
+
+        case "failed"
+            error('OKP job %s failed. Check https://predictor.openkinetics.org/ for details.', jobId);
+
+        otherwise % pending / running / queued
+            pct = '';
+            if isfield(statusResp,'progress') && isfield(statusResp.progress,'predictionsMade') ...
+                    && isfield(statusResp.progress,'predictionsTotal') && statusResp.progress.predictionsTotal > 0
+                pct = sprintf(' (%d/%d predictions)', statusResp.progress.predictionsMade, statusResp.progress.predictionsTotal);
+            end
+            if wait
+                fprintf('OKP job %s status: %s%s. Waiting %d s...\n', jobId, char(statusResp.status), pct, pollInterval);
+                pause(pollInterval);
+            else
+                fprintf(['OKP job %s not finished (status: %s%s).\n' ...
+                         'Try again later with fetchOpenKineticsPredictor, ' ...
+                         'or check https://predictor.openkinetics.org/.\n'], ...
+                         jobId, char(statusResp.status), pct);
+                done = false;
+                kcatList = [];
+                return
+            end
+    end
+end
+end
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+function jobId = readJobIdFromMeta(metaFile)
+if ~exist(metaFile,'file')
+    error(['No jobId provided and no metadata file at %s. Run ' ...
+           'submitOpenKineticsPredictor first, or pass jobId explicitly.'], metaFile);
+end
+lines = strsplit(fileread(metaFile), newline);
+jobId = '';
+for i=1:numel(lines)
+    tok = regexp(strtrim(lines{i}), '^jobId:\s*(\S+)$', 'tokens', 'once');
+    if ~isempty(tok); jobId = tok{1}; break; end
+end
+if isempty(jobId)
+    error('Could not read a jobId from %s.', metaFile);
+end
+end

--- a/src/geckomat/gather_kcats/resolveOkpApiKey.m
+++ b/src/geckomat/gather_kcats/resolveOkpApiKey.m
@@ -1,0 +1,47 @@
+function key = resolveOkpApiKey(argKey, basePath)
+% resolveOkpApiKey  Resolve the OpenKineticsPredictor API key.
+%
+% Internal helper shared by submitOpenKineticsPredictor and
+% fetchOpenKineticsPredictor; not intended to be called directly.
+%
+% Checked in order: the argKey input, the OKP_API_KEY environment variable,
+% then a plain-text file data/okpApiKey.txt under basePath (this name is
+% git-ignored by GECKO). The key is a secret and must never be read from the
+% model adapter, which is shared/committed.
+%
+% Parameters
+% ----------
+% argKey : char
+%     an explicitly provided key, or empty to fall through to the
+%     environment variable / file.
+% basePath : char
+%     the model adapter's params.path, under which data/okpApiKey.txt is
+%     looked up.
+%
+% Returns
+% -------
+% key : char
+%     the resolved API key.
+%
+% See also
+% --------
+% submitOpenKineticsPredictor, fetchOpenKineticsPredictor
+
+if ~isempty(argKey)
+    key = strtrim(char(argKey));
+    return
+end
+envKey = getenv('OKP_API_KEY');
+if ~isempty(envKey)
+    key = strtrim(envKey);
+    return
+end
+keyFile = fullfile(basePath,'data','okpApiKey.txt');
+if exist(keyFile,'file')
+    key = strtrim(fileread(keyFile));
+    return
+end
+error(['No OpenKineticsPredictor API key found. Provide it as the apiKey ' ...
+       'argument, set the OKP_API_KEY environment variable, or place it in ' ...
+       '%s. Generate a key at https://predictor.openkinetics.org/.'], keyFile);
+end

--- a/src/geckomat/gather_kcats/submitOpenKineticsPredictor.m
+++ b/src/geckomat/gather_kcats/submitOpenKineticsPredictor.m
@@ -1,0 +1,179 @@
+function jobId = submitOpenKineticsPredictor(model, varargin)
+% submitOpenKineticsPredictor  Submit a kcat prediction job to OpenKineticsPredictor.
+%
+% Builds the OpenKineticsPredictor input (protein sequences + single-substrate
+% SMILES, via writeOpenKineticsPredictorInput) and submits a kcat prediction
+% job to the OKP REST API (https://predictor.openkinetics.org/). The returned
+% job id is also stored in data/OKP_job.txt, so fetchOpenKineticsPredictor can
+% pick it up later.
+%
+% Predictors available via OKP: CataPro, CatPred, DLKcat, EITLEM, KinForm-H,
+% KinForm-L, UniKP (see GET /api/v1/methods/).
+%
+% Obtaining an API key:
+%   The OKP API requires a personal Bearer key (looks like 'ak_...'). Keys
+%   are free and need no registration:
+%     1. Open https://predictor.openkinetics.org/api-docs in a browser.
+%     2. In the "API key generator" section, click "Generate".
+%     3. Copy the key shown (it is displayed only once). If you lose it,
+%        revoke it on the same page and generate a new one.
+%   Keys are tied to your IP and carry a daily prediction quota that resets
+%   at midnight UTC.
+%
+%   The key is a secret; do NOT put it in the model adapter (which is
+%   shared/committed). Provide it in one of three ways, checked in this
+%   order: the apiKey argument below; the OKP_API_KEY environment variable
+%   (setenv('OKP_API_KEY',...)); or a plain-text file data/okpApiKey.txt in
+%   the model's data folder (this name is git-ignored by GECKO).
+%
+% Parameters
+% ----------
+% model : struct
+%     ecModel in GECKO 3 format (with ecModel.ec structure).
+%
+% Name-Value Arguments
+% --------------------
+% ecRxns : logical
+%     logical vector indicating which reactions to include (default: all
+%     reactions).
+% overwrite : logical
+%     rebuild data/OKP.csv even if it exists (default false; an existing
+%     file is reused).
+% apiKey : char
+%     OKP API key (default: resolved from OKP_API_KEY or data/okpApiKey.txt,
+%     see above).
+% method : char
+%     predictor to use (default: params.okp.method, or 'CataPro').
+% modelAdapter : ModelAdapter
+%     a loaded model adapter (default: the current default model adapter).
+%
+% Returns
+% -------
+% jobId : char
+%     the OKP job identifier (also written to data/OKP_job.txt).
+%
+% Examples
+% --------
+%     jobId = submitOpenKineticsPredictor(model);
+%     jobId = submitOpenKineticsPredictor(model, 'overwrite', true, 'apiKey', 'ak_...', 'method', 'DLKcat');
+%
+% See also
+% --------
+% fetchOpenKineticsPredictor, writeOpenKineticsPredictorInput
+
+p = parseGECKOargs(varargin, { ...
+    'ecRxns',       []; ...
+    'overwrite',    []; ...
+    'apiKey',       []; ...
+    'method',       []; ...
+    'modelAdapter', []});
+ecRxns       = p.ecRxns;
+overwrite    = p.overwrite;
+apiKey       = p.apiKey;
+method       = p.method;
+modelAdapter = p.modelAdapter;
+
+if isempty(modelAdapter)
+    modelAdapter = ModelAdapterManager.getDefault();
+    if isempty(modelAdapter)
+        error('Either provide a modelAdapter or set the default in ModelAdapterManager.')
+    end
+end
+params = modelAdapter.params;
+
+if isempty(overwrite)
+    overwrite = false;
+end
+if isempty(ecRxns)
+    ecRxns = true(numel(model.ec.rxns),1);
+elseif ~islogical(ecRxns) || numel(ecRxns) ~= numel(model.ec.rxns)
+    error('ecRxns should be a logical vector with length equal to model.ec.rxns')
+end
+
+apiKey = resolveOkpApiKey(apiKey, params.path);
+
+% Resolve predictor method and request options: defaults -> params.okp.* ->
+% the method argument (highest priority, applied last).
+okp = struct('method','CataPro', ...
+             'handleLongSequences','truncate', ...
+             'includeSimilarityColumns',true,'canonicalizeSubstrates',true);
+if isfield(params,'okp')
+    fn = fieldnames(params.okp);
+    for i=1:numel(fn); okp.(fn{i}) = params.okp.(fn{i}); end
+end
+if ~isempty(method)
+    okp.method = method;
+end
+
+%% Build (or reuse) the input CSV --- the same function, writing the same
+% file, as the file-based workflow (writeOpenKineticsPredictorInput /
+% readOpenKineticsPredictorOutput), rather than a separate reimplementation.
+filename = fullfile(params.path,'data','OKP.csv');
+if exist(filename,'file') && ~overwrite
+    fprintf('Using existing %s (set overwrite=true to rebuild).\n', filename);
+else
+    writeOpenKineticsPredictorInput(model, 'ecRxns', ecRxns, 'modelAdapter', modelAdapter, ...
+        'onlyWithSmiles', true, 'overwrite', true);
+end
+
+%% Submit via the OKP REST API
+% GECKO only ever predicts kcat.
+url = 'https://predictor.openkinetics.org/api/v1/submit/';
+
+targetsJson = '["kcat"]';
+methodsJson = ['{"kcat":"' okp.method '"}'];
+
+import matlab.net.http.*
+import matlab.net.http.io.*
+provider = MultipartFormProvider( ...
+    'file',                     FileProvider(filename), ...
+    'targets',                  targetsJson, ...
+    'methods',                  methodsJson, ...
+    'handleLongSequences',      okp.handleLongSequences, ...
+    'includeSimilarityColumns', boolToStr(okp.includeSimilarityColumns), ...
+    'canonicalizeSubstrates',   boolToStr(okp.canonicalizeSubstrates));
+header = matlab.net.http.HeaderField('Authorization', ['Bearer ' apiKey]);
+req    = RequestMessage('POST', header, provider);
+resp   = req.send(url);
+
+data = resp.Body.Data;
+if resp.StatusCode ~= matlab.net.http.StatusCode.OK && ...
+        resp.StatusCode ~= matlab.net.http.StatusCode.Created
+    error('OKP submit failed (HTTP %d): %s', double(resp.StatusCode), okpErrorText(data));
+end
+if ~isstruct(data) || ~isfield(data,'jobId')
+    error('OKP submit returned an unexpected response (no jobId).');
+end
+jobId = data.jobId;
+
+%% Persist job metadata (plain text, one field per line)
+metaFile = fullfile(params.path,'data','OKP_job.txt');
+fID = fopen(metaFile,'w');
+fprintf(fID,'jobId: %s\n', jobId);
+fprintf(fID,'method: %s\n', okp.method);
+fprintf(fID,'submittedAt: %s\n', char(datetime('now','TimeZone','UTC','Format','yyyy-MM-dd''T''HH:mm:ss''Z''')));
+fclose(fID);
+
+fprintf('Submitted OKP job %s (method: %s). Metadata stored at %s\n', jobId, okp.method, metaFile);
+fprintf('Check progress later with fetchOpenKineticsPredictor, or at https://predictor.openkinetics.org/\n');
+end
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+function s = boolToStr(b)
+if islogical(b) || isnumeric(b)
+    if b; s = 'true'; else; s = 'false'; end
+else
+    s = char(b);
+end
+end
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+function txt = okpErrorText(data)
+if isstruct(data) && isfield(data,'error')
+    txt = data.error;
+elseif ischar(data) || isstring(data)
+    txt = char(data);
+else
+    txt = 'unknown error';
+end
+end

--- a/test/unit_tests/geckoCoreFunctionTests.m
+++ b/test/unit_tests/geckoCoreFunctionTests.m
@@ -1120,3 +1120,85 @@ function testRelaxProteomicsGreedyMaxIterationsRaises_tc0028(testCase)
     verifyTrue(testCase, raised)
 end
 
+
+function testResolveOkpApiKeyResolutionOrder_tc0029(testCase)
+    % resolveOkpApiKey: argKey beats the OKP_API_KEY environment variable,
+    % which beats data/okpApiKey.txt, which beats erroring when none are set.
+    % Shared by submitOpenKineticsPredictor and fetchOpenKineticsPredictor;
+    % tested directly since neither caller can be run end-to-end without a
+    % live API key (same reasoning runDLKcat's own Docker dependency keeps
+    % it out of this suite --- external-service calls aren't unit tested
+    % here, only the logic that doesn't need one).
+    scratchDir = fullfile(tempname);
+    mkdir(fullfile(scratchDir,'data'));
+    cleanupDir = onCleanup(@() rmdir(scratchDir, 's'));
+
+    oldEnv = getenv('OKP_API_KEY');
+    cleanupEnv = onCleanup(@() setenv('OKP_API_KEY', oldEnv));
+
+    % Nothing set anywhere: errors.
+    setenv('OKP_API_KEY', '');
+    try
+        resolveOkpApiKey('', scratchDir);
+        raised = false;
+    catch
+        raised = true;
+    end
+    verifyTrue(testCase, raised)
+
+    % File only.
+    fID = fopen(fullfile(scratchDir,'data','okpApiKey.txt'), 'w');
+    fprintf(fID, 'ak_from_file');
+    fclose(fID);
+    verifyEqual(testCase, resolveOkpApiKey('', scratchDir), 'ak_from_file')
+
+    % Env beats file.
+    setenv('OKP_API_KEY', 'ak_from_env');
+    verifyEqual(testCase, resolveOkpApiKey('', scratchDir), 'ak_from_env')
+
+    % Explicit arg beats both.
+    verifyEqual(testCase, resolveOkpApiKey('ak_from_arg', scratchDir), 'ak_from_arg')
+end
+
+
+function testFetchOpenKineticsPredictorUseStoredMatchesReader_tc0030(testCase)
+    % fetchOpenKineticsPredictor's useStored path is the one code path that
+    % needs no live API call (parse an already-downloaded result file), so
+    % it's the one directly testable here. It now delegates to
+    % readOpenKineticsPredictorOutput instead of its own separate parsing
+    % subfunction (the pre-port version of this file duplicated ~90 lines of
+    % that parsing logic, which had drifted: it never added the 'OKP-'
+    % prefix readOpenKineticsPredictorOutput.m puts on kcatSource, and it
+    % computed kcatList.source as "the most frequent provenance" instead of
+    % the constant 'OpenKineticsPredictor' every other kcat-gathering
+    % function uses). Confirms the two entry points now produce identical
+    % kcatList structs from the same result file.
+    geckoPath = findGECKOroot;
+    adapter = ModelAdapterManager.getAdapter(fullfile(geckoPath,'test','unit_tests','ecTestGEM', 'TestGEMAdapter.m'));
+    model = getGeckoTestModel();
+    ecModel = makeEcModel(model, false, adapter);
+    ecModel = getECfromGEM(ecModel);
+    ecModel.metSmiles = repmat({''}, numel(ecModel.mets), 1);
+    ecModel.metSmiles(strcmp(ecModel.mets,'m1c')) = {'C(C1C)O'};
+
+    scratchDir = fullfile(tempname);
+    mkdir(fullfile(scratchDir,'data'));
+    cleanupDir = onCleanup(@() rmdir(scratchDir, 's'));
+    fetchAdapter = adapter;
+    fetchAdapter.params.path = scratchDir;
+
+    resultFile = fullfile(scratchDir,'data','OKP_output.csv');
+    fid = fopen(resultFile,'w');
+    fprintf(fid,'kcat (1/s),Source kcat,Extra Info kcat,Protein Sequence,Substrate\n');
+    fprintf(fid,'12.5,Prediction from CataPro,,MRAL,C(C1C)O\n');
+    fclose(fid);
+
+    [done, viaFetch] = fetchOpenKineticsPredictor(ecModel, 'useStored', true, 'modelAdapter', fetchAdapter);
+    verifyTrue(testCase, done)
+
+    viaReader = readOpenKineticsPredictorOutput(ecModel, 'outFile', resultFile, 'modelAdapter', fetchAdapter);
+    verifyEqual(testCase, viaFetch, viaReader)
+    verifyEqual(testCase, viaFetch.kcatSource, {'OKP-CataPro'})
+    verifyEqual(testCase, viaFetch.source, 'OpenKineticsPredictor')
+end
+


### PR DESCRIPTION
Adds `submitOpenKineticsPredictor.m` / `fetchOpenKineticsPredictor.m`: submit a kcat-prediction job to the OKP REST API and poll/fetch/parse the result, instead of the manual upload/download `writeOpenKineticsPredictorInput.m` / `readOpenKineticsPredictorOutput.m` require. Matches geckopy's own `submit_open_kinetics_predictor` / `fetch_open_kinetics_predictor`. Closes [SysBioChalmers/raven-gecko-parity#25](https://github.com/SysBioChalmers/raven-gecko-parity/issues/25).

## Where this comes from

Both functions already exist, written, on `feat/geckopy-compat` — but that branch is 84 commits ahead of `develop4` *and* 99 commits behind it, so merging it directly would be large and conflict-heavy, well beyond OKP. This PR cherry-picks and rebuilds just the two OKP functions against current `develop4` instead.

## Refactored during the port, not carried over as-is

- **Both functions now delegate to `writeOpenKineticsPredictorInput` / `readOpenKineticsPredictorOutput`** for CSV building/parsing, instead of each carrying its own ~90-line reimplementation. This fixes two real problems the duplication had caused:
  - The `feat/geckopy-compat` CSV-builder was forked *before* [GECKO #437](https://github.com/SysBioChalmers/GECKO/pull/437)'s fix and inherited the identical reaction-subset indexing bug (a caller-requested subset that skips an earlier `ec.rxns` entry could silently drop a later reaction's enzyme). Delegating means it can't drift out of sync with that fix again.
  - The `feat/geckopy-compat` result-parser never added the `OKP-` prefix `readOpenKineticsPredictorOutput.m` puts on `kcatSource`, and computed `kcatList.source` as "the most frequent provenance" instead of the constant `'OpenKineticsPredictor'` every other kcat-gathering function uses — an inconsistency between GECKO's own file-based and REST-based OKP paths that delegation removes.
- **Converted from positional `nargin`-based arguments to `parseGECKOargs` name-value arguments**, matching every function added to this codebase since (this branch predates that convention reaching this file).
- **Extracted the duplicated API-key resolution** (identical in both files) into a shared `resolveOkpApiKey.m`.

## Verification

`resolveOkpApiKey`'s resolution order (arg > `OKP_API_KEY` env > `data/okpApiKey.txt` > error) is fully unit tested. `fetchOpenKineticsPredictor`'s `useStored` path (parse an already-downloaded result — the one code path needing no live API call) is verified to produce an identical `kcatList` to calling `readOpenKineticsPredictorOutput` directly. The HTTP-calling majority of both functions isn't unit tested, for the same reason `runDLKcat`'s own Docker dependency keeps it out of this suite — this codebase doesn't yet have external-service mocking infrastructure. Full `geckoCoreFunctionTests` suite: 30 passed, 0 failed.
