### PR TITLE
fix: four EC-code and kcat data-quality bugs

### DIFF
--- a/src/geckomat/gather_kcats/fuzzyKcatMatching.m
+++ b/src/geckomat/gather_kcats/fuzzyKcatMatching.m
@@ -237,10 +237,18 @@ for k = 1:length(EC)
             success   = true;
             wc_num(k) = sum(EC{k}=='-');
         else
-            dot_pos  = [2 strfind(EC{k},'.')];
             wild_num = sum(EC{k}=='-');
-            wc_text  = '-.-.-.-';
-            EC{k}    = [EC{k}(1:dot_pos(4-wild_num)) wc_text(1:2*wild_num+1)];
+            if wild_num >= 4
+                %Already fully wildcarded ('-.-.-.-') and still no match --
+                %stop here instead of computing dot_pos(4-wild_num) with
+                %wild_num==4, an out-of-range index. kcat(k)/origin(k) keep
+                %their zero-initialised "no match" values.
+                success = true;
+            else
+                dot_pos  = [2 strfind(EC{k},'.')];
+                wc_text  = '-.-.-.-';
+                EC{k}    = [EC{k}(1:dot_pos(4-wild_num)) wc_text(1:2*wild_num+1)];
+            end
         end
     end
 end

--- a/src/geckomat/gather_kcats/getStandardKcat.m
+++ b/src/geckomat/gather_kcats/getStandardKcat.m
@@ -275,8 +275,13 @@ for i = 1:numel(rxnsMissingGPR)
     end
 
     if ~standard
+        % kcatSubSystemIdx is a one-hot vector (the reaction's first subSystem
+        % matched against every subSystem that has a computed kcat); any(), not
+        % all(), is the right test -- all() only ever succeeds when the model
+        % has exactly one subSystem in total, silently falling back to the
+        % model-wide standardKcat for every reaction otherwise.
         kcatSubSystemIdx = strcmpi(enzSubSystem_names, model.subSystems{rxnIdx}(1));
-        if all(kcatSubSystemIdx)
+        if any(kcatSubSystemIdx)
             model.ec.kcat(end+1) = kcatSubSystem(kcatSubSystemIdx);
         else
             model.ec.kcat(end+1) = standardKcat;

--- a/src/geckomat/get_enzyme_data/findECInDB.m
+++ b/src/geckomat/get_enzyme_data/findECInDB.m
@@ -133,6 +133,10 @@ for i = 1:length(prev_EC)
         end
     end
 end
+%When prev_EC carries both a code and its own wildcard parent (e.g.
+%'EC1.1.1.1' and 'EC1.1.1.-'), both independently pair-match the same
+%new_EC entry above and the loop appends the resolved code twice; dedupe.
+int_EC = unique(int_EC,'stable');
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 function int_EC = compare_wild(EC)

--- a/src/geckomat/get_enzyme_data/getECfromGEM.m
+++ b/src/geckomat/get_enzyme_data/getECfromGEM.m
@@ -60,9 +60,12 @@ end
 
 [~,rxnIdxs] = ismember(rxnNames,model.rxns);
 
-% Check if eccodes are valid
+% Check if eccodes are valid. Each of the four dot-separated components must
+% be either a run of digits or the wildcard '-'; \w (the previous class) also
+% matches letters and underscores, so malformed codes such as '1.1.1.n12' or
+% '1_2_3_4' were incorrectly accepted.
 eccodes = model.eccodes;
-invalidEC = regexprep(eccodes,'(\d\.(\w|-)+\.(\w|-)+\.(\w|-)+)(;\w+\.(\w|-)+\.(\w|-)+\.(\w|-)+)*(.*)','$3');
+invalidEC = regexprep(eccodes,'(\d+\.(\d+|-)\.(\d+|-)\.(\d+|-))(;\d+\.(\d+|-)\.(\d+|-)\.(\d+|-))*(.*)','$3');
 invalidEC = ~cellfun(@isempty,invalidEC);
 invalidECpos = find(invalidEC);
 if any(invalidECpos)

--- a/test/unit_tests/geckoCoreFunctionTests.m
+++ b/test/unit_tests/geckoCoreFunctionTests.m
@@ -1202,3 +1202,130 @@ function testFetchOpenKineticsPredictorUseStoredMatchesReader_tc0030(testCase)
     verifyEqual(testCase, viaFetch.source, 'OpenKineticsPredictor')
 end
 
+
+function testGetECfromGEMRejectsMalformedComponents_tc0031(testCase)
+    % getECfromGEM's validity regex used \w (any word character) instead of
+    % \d+ for each of the four EC components, so malformed strings containing
+    % letters or underscores -- e.g. '1.1.1.n12' (a real BRENDA "undefined
+    % subclass"-style code) or '1_2_3_4' -- passed validation and were kept
+    % instead of being rejected. geckopy's fill_eccodes_from_gem already
+    % requires each component to be purely digits or the wildcard '-'; this
+    % brings MATLAB's validation in line, and closes an already-documented
+    % divergence (raven-gecko-parity's ledgers/gecko.yml, getECfromGEM row).
+    clear model
+    model.rxns = {'R1';'R2';'R3';'R4'};
+    model.eccodes = {'1.1.1.1'; '1.1.1.n12'; '1_2_3_4'; '1.2.3.-'};
+    model.ec.rxns = model.rxns;
+    model.ec.geckoLight = false;
+
+    ecModel = getECfromGEM(model);
+    expected = {'1.1.1.1'; ''; ''; '1.2.3.-'};
+    verifyEqual(testCase, ecModel.ec.eccodes, expected)
+end
+
+
+function testFindECInDBIntersectionDedupesWildcardPair_tc0032(testCase)
+    % findECInDB's private intersection() helper does not dedupe its output:
+    % when prev_EC contains both a specific EC code and its own wildcard
+    % parent (e.g. '1.1.1.1' and '1.1.1.-'), both independently pair-match
+    % the same entry in new_EC, and the inner loop appends the resolved code
+    % twice -- e.g. producing '1.1.1.1;1.1.1.1' instead of '1.1.1.1'.
+    %
+    % Gene 1 maps to a single protein annotated with two EC tokens,
+    % '1.1.1.1' and its own wildcard parent '1.1.1.-' (space-separated, the
+    % format getECstring expects for one protein's multiple activities);
+    % gene 2 maps to a single protein annotated with just '1.1.1.1'.
+    % Reconciling across the two genes (an AND-complex) via intersection
+    % must return the code once, not twice.
+    geneHashMap = containers.Map({'G1','G2'}, {1,2});
+    geneIndex = {1; 2};
+    DBecNum = {'1.1.1.1 1.1.1.-'; '1.1.1.1'};
+    DBMW = [10000; 20000];
+
+    EC = findECInDB({'G1','G2'}, DBecNum, DBMW, geneIndex, geneHashMap);
+    verifyEqual(testCase, EC, '1.1.1.1')
+end
+
+
+function testFuzzyKcatMatchingWildcardExhaustionDoesNotCrash_tc0033(testCase)
+    % iterativeMatch's wildcard-escalation loop had no termination guard: once
+    % an EC token is escalated to fully wildcarded ('-.-.-.-') and still finds
+    % no BRENDA match, the next escalation attempt computed
+    % dot_pos(4-wild_num) with wild_num==4 -- dot_pos(0), an invalid index --
+    % and errored instead of reporting "no match". Reachable for any EC class
+    % with zero BRENDA coverage even at the broadest wildcard level.
+    geckoPath = findGECKOroot;
+    adapter = ModelAdapterManager.getAdapter(fullfile(geckoPath,'test','unit_tests','ecTestGEM', 'TestGEMAdapter.m'));
+    model = getGeckoTestModel();
+    ecModel = makeEcModel(model, false, adapter);
+    ecModel = getECfromGEM(ecModel);
+    % An EC class unrelated, at every wildcard level, to anything in the
+    % fixture BRENDA file below.
+    ecModel.ec.eccodes{strcmp(ecModel.ec.rxns, 'R2_EXP_1')} = '9.9.9.9';
+
+    scratchDir = fullfile(tempname);
+    brendaDir = fullfile(scratchDir, 'data');
+    mkdir(brendaDir);
+    cleanupDir = onCleanup(@() rmdir(scratchDir, 's'));
+    % Deliberately unrelated to '9.9.9.9' at every wildcard level, so the
+    % escalation loop runs out of levels without ever matching.
+    fid = fopen(fullfile(brendaDir, 'max_KCAT.txt'), 'w');
+    fprintf(fid, 'EC5.5.5.5\tm1\ttestus testus//*//*\t42\t*\n');
+    fclose(fid);
+    fid = fopen(fullfile(brendaDir, 'max_MW.txt'), 'w');
+    fprintf(fid, 'EC0.0.0.0\t*\tplaceholder//*//*\t1\t*\n');
+    fclose(fid);
+    fid = fopen(fullfile(brendaDir, 'max_SA.txt'), 'w');
+    fprintf(fid, 'EC0.0.0.0\t*\tplaceholder//*//*\t1\t*\n');
+    fclose(fid);
+    % getPhylDistStructPath also resolves under params.path/data; reuse
+    % ecTestGEM's own real fixture rather than fabricating a second one.
+    copyfile(fullfile(geckoPath,'test','unit_tests','ecTestGEM','data','PhylDist.mat'), ...
+        fullfile(brendaDir, 'PhylDist.mat'));
+
+    fuzzyAdapter = adapter;
+    fuzzyAdapter.params.path = scratchDir;
+
+    % Must complete without erroring, and report a clean "no match" rather
+    % than crashing or leaving a garbled value.
+    kcatList = fuzzyKcatMatching(ecModel, ismember(ecModel.ec.rxns,{'R2_EXP_1'}), fuzzyAdapter);
+    verifyEqual(testCase, kcatList.kcats, 0)
+    verifyTrue(testCase, isnan(kcatList.origin))
+end
+
+
+function testGetStandardKcatUsesSubsystemKcatWheneverAnyMatches_tc0034(testCase)
+    % kcatSubSystemIdx is a one-hot vector produced by comparing a reaction's
+    % first subSystem against every subSystem that has a computed kcat;
+    % all(kcatSubSystemIdx) only ever succeeds for a model with exactly one
+    % subSystem in total. With more than one subSystem, that branch never
+    % fires and every reaction silently falls back to the model-wide
+    % standardKcat, masking the subsystem-specific kcat this code path
+    % exists to apply.
+    %
+    % R1 has no GPR and shares subSystem 'SubA' with R3 (kcat 50); R5 sits in
+    % a different subSystem 'SubB' (kcat 999, deliberately large so it would
+    % skew the model-wide median standardKcat fallback if picked by
+    % mistake). With two distinct subSystems in play, R1 must be assigned
+    % SubA's kcat (50), not the fallback.
+    geckoPath = findGECKOroot;
+    adapter = ModelAdapterManager.getAdapter(fullfile(geckoPath,'test','unit_tests','ecTestGEM', 'TestGEMAdapter.m'));
+    model = getGeckoTestModel();
+    ecModel = makeEcModel(model, false, adapter);
+    ecModel = getECfromGEM(ecModel);
+    ecModel.ec.kcat(:) = 0;
+    ecModel.ec.kcat(strcmp(ecModel.ec.rxns,'R3')) = 50;
+    ecModel.ec.kcat(strcmp(ecModel.ec.rxns,'R5')) = 999;
+    ecModel.ec.source(:) = {'manual'};
+
+    ecModel.subSystems = repmat({{''}}, size(ecModel.rxns));
+    ecModel.subSystems(strcmp(ecModel.rxns,'R1')) = {{'SubA'}};
+    ecModel.subSystems(strcmp(ecModel.rxns,'R3')) = {{'SubA'}};
+    ecModel.subSystems(strcmp(ecModel.rxns,'R5')) = {{'SubB'}};
+
+    ecModel = getStandardKcat(ecModel, 'modelAdapter', adapter, 'threshold', 1, 'fillZeroKcat', false);
+
+    r1kcat = ecModel.ec.kcat(strcmp(ecModel.ec.rxns,'R1'));
+    verifyEqual(testCase, r1kcat, 50)
+end
+


### PR DESCRIPTION
## Summary

Four small, independent bug fixes to EC-code handling and kcat gathering, each with its own tracking issue and regression test:

- **fuzzyKcatMatching.m** (#442): the wildcard-escalation loop had no termination guard, so an EC class with zero BRENDA coverage even at full wildcard (`-.-.-.-`) crashed instead of reporting no match.
- **getECfromGEM.m** (#443): the EC validation regex used `\w` instead of `\d+` per component, so malformed codes containing letters or underscores (e.g. `1.1.1.n12`, `1_2_3_4`) passed validation instead of being rejected. This also closes an already-documented divergence in `raven-gecko-parity`'s ledger, where `geckopy.fill_eccodes_from_gem` correctly rejects these and `getECfromGEM.m` didn't.
- **findECInDB.m** (#444): the `intersection()` helper didn't dedupe its output, so a specific EC code and its own wildcard parent (e.g. `1.1.1.1` and `1.1.1.-`) could both resolve to the same code and get appended twice.
- **getStandardKcat.m** (#445): `kcatSubSystemIdx` is a one-hot vector, so `all(kcatSubSystemIdx)` only ever succeeds for a model with exactly one subSystem in total; `any()` is the correct test. With more than one subSystem, every reaction silently fell back to the model-wide `standardKcat` instead of its own subSystem-specific value.

All four were originally diagnosed and fixed on the long-abandoned `feat/geckopy-compat` branch (84 commits ahead of `develop4`, but also 99 behind it — not mergeable as-is), while building out `raven-gecko-parity`'s MATLAB/Python behavioural parity tests. Re-verified against current `develop4` and re-implemented here rather than merging that branch.

In three of the four cases, geckopy's own port already documents (or simply implements) the corrected behavior, which was used to confirm the fix matches the intended cross-language behaviour rather than just silencing an error.

## Test plan

- [x] Added `testGetECfromGEMRejectsMalformedComponents_tc0031`, `testFindECInDBIntersectionDedupesWildcardPair_tc0032`, `testFuzzyKcatMatchingWildcardExhaustionDoesNotCrash_tc0033`, `testGetStandardKcatUsesSubsystemKcatWheneverAnyMatches_tc0034` to `geckoCoreFunctionTests.m`.
- [x] Verified each new test fails against the pre-fix code (including reproducing the actual crash for tc0033) and passes against the fix.
- [x] Full local suite: 34/34 passed.

Closes #442, #443, #444, #445.