### PR TITLE
fix: case-insensitive DLKcat substrate match, stable ec.genes order, dead code

### DIFF
--- a/src/geckomat/change_model/makeEcModel.m
+++ b/src/geckomat/change_model/makeEcModel.m
@@ -282,10 +282,13 @@ elseif ~isempty(noUniprot)
         'data (e.g. from a different proteome, make sure you first delete '...
         'the existing data/uniprot.tsv file.\n']);
 end
-ec.genes        = model.genes(Lia); %Will often be duplicate of model.genes, but is done here to prevent issues when it is not.
-ec.enzymes      = uniprotDB.ID(Locb(Lia));
-ec.mw           = uniprotDB.MW(Locb(Lia));
-ec.sequence     = uniprotDB.seq(Locb(Lia));
+%Sort alphabetically so ec.genes has a stable order across runs.
+[ec.genes,sIdx] = sort(model.genes(Lia)); %Will often be duplicate of model.genes, but is done here to prevent issues when it is not.
+LocbSorted      = Locb(Lia);
+LocbSorted      = LocbSorted(sIdx);
+ec.enzymes      = uniprotDB.ID(LocbSorted);
+ec.mw           = uniprotDB.MW(LocbSorted);
+ec.sequence     = uniprotDB.seq(LocbSorted);
 %Additional info
 ec.concs        = nan(numel(ec.genes),1); % To be filled with proteomics data when available
 

--- a/src/geckomat/gather_kcats/fuzzyKcatMatching.m
+++ b/src/geckomat/gather_kcats/fuzzyKcatMatching.m
@@ -179,9 +179,6 @@ while forceWClvl > 0
     eccodes=regexprep(eccodes,'(.)*(\.\d+)(\.-)*$','$1\.-$3');
     forceWClvl = forceWClvl - 1;
 end
-if forceWClvl == 1
-    eccodes = regexprep(eccodes,'.*','-\.-\.-\.-');
-end
 
 PB = progressReport(mM, 'Gathering kcat values by fuzzy matching to BRENDA database');
 %Main loop:

--- a/src/geckomat/gather_kcats/readDLKcatOutput.m
+++ b/src/geckomat/gather_kcats/readDLKcatOutput.m
@@ -73,8 +73,10 @@ if all(cellfun(@isempty,kcats)) || all(strcmpi(kcats,'NA'))
     error('DLKcat file does not contain any kcat values, please run runDLKcat() first.')
 end
 
-% Check that all substrates are in the model
-matchMets = ismember(subs,model.metNames);
+% Check that all substrates are in the model (case-insensitive: an SBML loader can
+% normalise metabolite-name capitalisation differently than whatever produced the
+% DLKcat input, and that must not read as a genuinely missing substrate).
+matchMets = ismember(lower(subs),lower(model.metNames));
 if ~all(matchMets)
     errorText = 'DLKcat was likely run with an input file that was generated from another ecModel, as the following substrates from DLKcat output cannot be found in model.metNames:';
     dispEM(errorText,true,subs(~matchMets),false)

--- a/test/unit_tests/geckoCoreFunctionTests.m
+++ b/test/unit_tests/geckoCoreFunctionTests.m
@@ -1329,3 +1329,58 @@ function testGetStandardKcatUsesSubsystemKcatWheneverAnyMatches_tc0034(testCase)
     verifyEqual(testCase, r1kcat, 50)
 end
 
+
+function testReadDLKcatOutputSubstrateMatchIsCaseInsensitive_tc0035(testCase)
+    % readDLKcatOutput's substrate-name check against model.metNames used ismember's
+    % default case-sensitive comparison, so a DLKcat output file whose substrate names
+    % differ only in case from model.metNames -- e.g. an SBML loader that normalises
+    % capitalisation differently than whatever produced the DLKcat input -- was reported
+    % as "substrate not found" even though the same metabolite is genuinely present.
+    geckoPath = findGECKOroot;
+    adapter = ModelAdapterManager.getAdapter(fullfile(geckoPath,'test','unit_tests','ecTestGEM', 'TestGEMAdapter.m'));
+    model = getGeckoTestModel();
+    ecModel = makeEcModel(model, false, adapter);
+    ecModel = getECfromGEM(ecModel);
+
+    scratchDir = fullfile(tempname);
+    cleanupDir = onCleanup(@() rmdir(scratchDir, 's'));
+    mkdir(scratchDir);
+    outFile = fullfile(scratchDir,'DLKcat_output_test.tsv');
+    fid = fopen(outFile,'w');
+    fprintf(fid,'rxns\tgenes\tsubstrates\tsmiles\tsequence\tkcat\n');
+    % 'M1' (uppercase) against the model's own lowercase 'm1' -- must still match.
+    fprintf(fid,'R2_EXP_1\tG1\tM1\tsmiles\tseq\t12.5\n');
+    fclose(fid);
+
+    kcatList = readDLKcatOutput(ecModel, 'outFile', outFile, 'modelAdapter', adapter);
+    verifyEqual(testCase, kcatList.kcats, 12.5)
+    verifyEqual(testCase, kcatList.substrates, {'M1'})
+end
+
+
+function testMakeEcModelSortsEcGenes_tc0036(testCase)
+    % makeEcModel's ec.genes (and ec.enzymes/ec.mw/ec.sequence, permuted in lockstep) used
+    % to keep model.genes' own array order -- whatever order genes happened to be declared
+    % in, not necessarily alphabetical or reproducible across independently-built models of
+    % the same organism. ecTestGEM's genes (G1..G5) already happen to be declared
+    % alphabetically, so the existing makeEcModel tests don't exercise this: reorder them
+    % here so a passing test actually proves the sort, not an already-sorted pass-through.
+    geckoPath = findGECKOroot;
+    adapter = ModelAdapterManager.getAdapter(fullfile(geckoPath,'test','unit_tests','ecTestGEM', 'TestGEMAdapter.m'));
+    model = getGeckoTestModel();
+    newOrder = [5 3 1 4 2];
+    model.genes = model.genes(newOrder);
+    model.rxnGeneMat = model.rxnGeneMat(:,newOrder);
+
+    ecModel = makeEcModel(model, false, adapter);
+
+    expEcGenes = {'G1';'G2';'G3';'G4';'G5'};
+    verifyEqual(testCase,ecModel.ec.genes,expEcGenes)
+    expEnzymes = {'P1';'P2';'P3';'P4';'P5'};
+    verifyEqual(testCase,ecModel.ec.enzymes,expEnzymes)
+    expMW = [10000;20000;30000;40000;50000];
+    verifyEqual(testCase,ecModel.ec.mw,expMW)
+    expSequence = {'MRAL';'MNTD';'MSYN';'MDFM';'MLFK'};
+    verifyEqual(testCase,ecModel.ec.sequence,expSequence);
+end
+


### PR DESCRIPTION
## Summary

Three independent small fixes, each with its own tracking issue:

- **readDLKcatOutput.m** (#449): substrate-name matching against `model.metNames` was case-sensitive, causing spurious "substrate not found" failures when an SBML loader normalises capitalisation differently than whatever produced the DLKcat input. Now case-insensitive, matching geckopy's already-lenient `read_dlkcat_output`, whose own docstring documents this exact MATLAB gap.
- **makeEcModel.m** (#451): `ec.genes` (and `ec.enzymes`/`ec.mw`/`ec.sequence`, permuted in lockstep) now sort alphabetically, so the `ec` struct has a stable, comparable order across runs instead of whatever order the underlying data-gathering step happened to produce. Not a parity fix — geckopy's `make_ec_model` has no equivalent gene-ordering guarantee to match either, so this is a MATLAB-side determinism improvement on its own terms.
- **fuzzyKcatMatching.m** (#450): removed a dead `if forceWClvl == 1` block — the preceding `while` loop always decrements `forceWClvl` to exactly 0 first, so the branch could never fire. No behavioural change on either side.

A fourth reported bug (`saveEcModel.m`'s default filename lacking a `.yml` extension) turned out not to reproduce against current `develop4`: RAVEN's `writeYAMLmodel.m` already appends `.yml` unconditionally whenever it's missing, so the save/load round trip already produces and reads back `ecModel.yml` correctly today. Closed without a code change (#448) rather than ship a fix for a non-bug.

All four were originally diagnosed on the long-abandoned `feat/geckopy-compat` branch (commit `0b6b47f`, never merged — 99 commits behind `develop4`) and re-verified against current `develop4` here rather than merging that branch.

## A separate, more serious finding along the way

While writing the regression test for the `readDLKcatOutput.m` fix, reverting the fix to confirm the test failed correctly surfaced an **unrelated, currently-live crash**: `dispEM`, a RAVEN utility function, was removed from RAVEN in [SysBioChalmers/RAVEN#659](https://github.com/SysBioChalmers/RAVEN/pull/659) (merged 2026-06-18, already on `develop3`) and replaced with native `warning`/`error` + a new `ravenList` formatter. GECKO's `develop4` still calls the now-nonexistent `dispEM` in four places:

- `src/geckomat/gather_kcats/readDLKcatOutput.m` (2 call sites)
- `src/geckomat/get_enzyme_data/loadDatabases.m` (1)
- `src/geckomat/utilities/addNewRxnsToEC.m` (1)
- `src/geckomat/utilities/getSubsetEcModel.m` (1)

Each of these crashes with `Undefined function 'dispEM'` instead of reporting its intended warning/error whenever it reaches that branch — i.e. exactly when something is already wrong and the function is trying to tell the caller. Not fixed in this PR (out of scope for what was asked here); will follow up separately.

## Test plan

- [x] Added `testReadDLKcatOutputSubstrateMatchIsCaseInsensitive_tc0035` and `testMakeEcModelSortsEcGenes_tc0036` to `geckoCoreFunctionTests.m`.
- [x] Verified each new test fails against the pre-fix code and passes against the fix.
- [x] Full local suite: 36/36 passed.

Closes #449, #450, #451.