### PR TITLE
fix: replace dispEM (removed from RAVEN) with error+ravenList

### DIFF
--- a/src/geckomat/gather_kcats/readDLKcatOutput.m
+++ b/src/geckomat/gather_kcats/readDLKcatOutput.m
@@ -77,14 +77,14 @@ end
 matchMets = ismember(subs,model.metNames);
 if ~all(matchMets)
     errorText = 'DLKcat was likely run with an input file that was generated from another ecModel, as the following substrates from DLKcat output cannot be found in model.metNames:';
-    dispEM(errorText,true,subs(~matchMets),false)
+    error('%s', ravenList(errorText,subs(~matchMets),false))
 end
 
 % Check that all reactions are in model.ec.rxns
 matchRxns = ismember(rxns,model.ec.rxns);
 if ~all(matchRxns)
     errorText = 'DLKcat was likely run with an input file that was generated from another ecModel, as the following reactions from DLKcat output cannot be found in model.metNames:';
-    dispEM(errorText,true,rxns(~matchRxns),false)
+    error('%s', ravenList(errorText,rxns(~matchRxns),false))
 end
 
 % Filter out entries with no numeric value

--- a/src/geckomat/get_enzyme_data/loadDatabases.m
+++ b/src/geckomat/get_enzyme_data/loadDatabases.m
@@ -99,9 +99,9 @@ if any(strcmp(selectDatabase,{'uniprot','both'}))
         [uniqueIDs,uniqueIdx] = unique(databases.uniprot.ID,'stable');
         if numel(uniqueIDs) < numel(databases.uniprot.ID)
             duplID = setdiff(1:numel(databases.uniprot.ID),uniqueIdx);
-            dispEM(['Duplicate entries are found for the following proteins. '...
+            error('%s', ravenList(['Duplicate entries are found for the following proteins. '...
                     'Manually curate the ''uniprot.tsv'' file, or adjust the uniprot parameters '...
-                    'in the model adapter:'],true,databases.uniprot.ID(duplID));
+                    'in the model adapter:'],databases.uniprot.ID(duplID)));
         end
     end
 end

--- a/src/geckomat/utilities/addNewRxnsToEC.m
+++ b/src/geckomat/utilities/addNewRxnsToEC.m
@@ -147,7 +147,7 @@ else
     % newEnzymes input
     if ~isempty(genesInRules)
         errorText = 'The following genes from grRules are not present in the model, add them as newEnzymes input:';
-        dispEM(errorText,true,genesInRules,false)
+        error('%s', ravenList(errorText,genesInRules,false))
     end
 
     % Get reversible reactions to split

--- a/src/geckomat/utilities/getSubsetEcModel.m
+++ b/src/geckomat/utilities/getSubsetEcModel.m
@@ -33,9 +33,9 @@ function smallEcModel = getSubsetEcModel(bigEcModel,smallGEM)
 Rxn_format = regexprep(bigEcModel.rxns,'_REV|_EXP_\d+','');
 rxnsDiff = find(~ismember(smallGEM.rxns,Rxn_format));
 if numel(rxnsDiff) > 0
-    dispEM(['While both models should have derived from the same starting ',...
+    error('%s', ravenList(['While both models should have derived from the same starting ',...
             'GEM, the following reactions from smallGEM could not be found ',...
-            'in bigEcModel:'],true,smallGEM.rxns(rxnsDiff),false);
+            'in bigEcModel:'],smallGEM.rxns(rxnsDiff),false));
 end
 
 % Check if original bigEcModel contains context-dependent protein constraints

--- a/test/unit_tests/geckoCoreFunctionTests.m
+++ b/test/unit_tests/geckoCoreFunctionTests.m
@@ -1329,3 +1329,124 @@ function testGetStandardKcatUsesSubsystemKcatWheneverAnyMatches_tc0034(testCase)
     verifyEqual(testCase, r1kcat, 50)
 end
 
+
+function testReadDLKcatOutputUnrecognizedSubstrateErrorsCleanly_tc0035(testCase)
+    % dispEM (a RAVEN utility) was removed from RAVEN in RAVEN#659 and replaced with
+    % native warning/error + ravenList; readDLKcatOutput.m still called the now-nonexistent
+    % dispEM, so reporting a genuinely unrecognized substrate crashed with "Undefined
+    % function 'dispEM'" instead of the intended, informative error.
+    geckoPath = findGECKOroot;
+    adapter = ModelAdapterManager.getAdapter(fullfile(geckoPath,'test','unit_tests','ecTestGEM', 'TestGEMAdapter.m'));
+    model = getGeckoTestModel();
+    ecModel = makeEcModel(model, false, adapter);
+    ecModel = getECfromGEM(ecModel);
+
+    scratchDir = fullfile(tempname);
+    cleanupDir = onCleanup(@() rmdir(scratchDir, 's'));
+    mkdir(scratchDir);
+    outFile = fullfile(scratchDir,'DLKcat_output_test.tsv');
+    fid = fopen(outFile,'w');
+    fprintf(fid,'rxns\tgenes\tsubstrates\tsmiles\tsequence\tkcat\n');
+    fprintf(fid,'R2_EXP_1\tG1\tNOTAREALMETABOLITE\tsmiles\tseq\t12.5\n');
+    fclose(fid);
+
+    try
+        readDLKcatOutput(ecModel, 'outFile', outFile, 'modelAdapter', adapter);
+        errored = false;
+        msg = '';
+    catch ME
+        errored = true;
+        msg = ME.message;
+    end
+    verifyTrue(testCase, errored)
+    verifyFalse(testCase, contains(msg, 'dispEM'))
+    verifyTrue(testCase, contains(msg, 'NOTAREALMETABOLITE'))
+end
+
+
+function testLoadDatabasesDuplicateUniprotEntriesErrorsCleanly_tc0036(testCase)
+    % Same dispEM removal as tc0035, a different caller: loadDatabases.m's duplicate-entry
+    % check crashed with "Undefined function 'dispEM'" instead of reporting the duplicates.
+    geckoPath = findGECKOroot;
+    adapter = ModelAdapterManager.getAdapter(fullfile(geckoPath,'test','unit_tests','ecTestGEM', 'TestGEMAdapter.m'));
+
+    scratchDir = fullfile(tempname);
+    cleanupDir = onCleanup(@() rmdir(scratchDir, 's'));
+    mkdir(fullfile(scratchDir,'data'));
+    fid = fopen(fullfile(scratchDir,'data','uniprot.tsv'),'w');
+    fprintf(fid,'Entry\tGene Names (ordered locus)\tEC number\tMass\tSequence\n');
+    fprintf(fid,'P1\tG1\t1.1.1.1\t10000\tMRAL\n');
+    fprintf(fid,'P1\tG1\t1.1.1.1\t10000\tMRAL\n');
+    fclose(fid);
+
+    dbAdapter = adapter;
+    dbAdapter.params.path = scratchDir;
+
+    try
+        loadDatabases('uniprot', dbAdapter);
+        errored = false;
+        msg = '';
+    catch ME
+        errored = true;
+        msg = ME.message;
+    end
+    verifyTrue(testCase, errored)
+    verifyFalse(testCase, contains(msg, 'dispEM'))
+    verifyTrue(testCase, contains(msg, 'Duplicate entries'))
+end
+
+
+function testAddNewRxnsToECMissingGeneErrorsCleanly_tc0037(testCase)
+    % Same dispEM removal as tc0035, a different caller: addNewRxnsToEC.m's
+    % missing-gene check crashed with "Undefined function 'dispEM'" instead of naming
+    % the gene that needed to be passed as newEnzymes input.
+    geckoPath = findGECKOroot;
+    adapter = ModelAdapterManager.getAdapter(fullfile(geckoPath,'test','unit_tests','ecTestGEM', 'TestGEMAdapter.m'));
+    model = getGeckoTestModel();
+    ecModel = makeEcModel(model, false, adapter);
+
+    newRxns.rxns      = {'RNEWA'};
+    newRxns.rxnNames  = {'RNEWA'};
+    newRxns.equations = {'m1[c] => e2[e]'};
+    newRxns.grRules   = {'GNEW1 or GNEW2'};
+
+    % GNEW2 is referenced in grRules but deliberately left out of newEnzymes below.
+    newEnzymes.enzymes = {'ENEW1'};
+    newEnzymes.genes   = {'GNEW1'};
+    newEnzymes.mw      = 15000;
+
+    try
+        addNewRxnsToEC(ecModel, newRxns, newEnzymes, adapter);
+        errored = false;
+        msg = '';
+    catch ME
+        errored = true;
+        msg = ME.message;
+    end
+    verifyTrue(testCase, errored)
+    verifyFalse(testCase, contains(msg, 'dispEM'))
+    verifyTrue(testCase, contains(msg, 'GNEW2'))
+end
+
+
+function testGetSubsetEcModelMismatchedReactionsErrorsCleanly_tc0038(testCase)
+    % Same dispEM removal as tc0035, a different caller: getSubsetEcModel.m's
+    % same-starting-GEM check crashed with "Undefined function 'dispEM'" instead of
+    % naming the reactions that could not be matched.
+    clear bigEcModel smallGEM
+    bigEcModel.rxns = {'R1';'R2_EXP_1'};
+    smallGEM.rxns   = {'R1';'R3'};
+
+    try
+        getSubsetEcModel(bigEcModel, smallGEM);
+        errored = false;
+        msg = '';
+    catch ME
+        errored = true;
+        msg = ME.message;
+    end
+    verifyTrue(testCase, errored)
+    verifyFalse(testCase, contains(msg, 'dispEM'))
+    verifyTrue(testCase, contains(msg, 'R3'))
+end
+


### PR DESCRIPTION
## Summary

RAVEN deleted \`dispEM\` entirely in [SysBioChalmers/RAVEN#659](https://github.com/SysBioChalmers/RAVEN/pull/659) (merged 2026-06-18, already on \`develop3\`), replacing all 317 of its own call sites with native \`warning\`/\`error\` plus a new \`ravenList\` formatter. Four GECKO functions still called the now-nonexistent \`dispEM\`, so each crashed with \`Undefined function 'dispEM'\` instead of reporting its intended error whenever that branch was reached — i.e. exactly when something was already wrong and the function was trying to say so:

- \`readDLKcatOutput.m\` (unmatched substrates, unmatched reactions)
- \`loadDatabases.m\` (duplicate UniProt entries)
- \`addNewRxnsToEC.m\` (grRule genes missing from newEnzymes)
- \`getSubsetEcModel.m\` (smallGEM/bigEcModel reaction mismatch)

Every one of these call sites used \`throwErrors=true\`, so each becomes a plain \`error('%s', ravenList(...))\` — matching this codebase's own existing convention of unidentified \`error()\` calls (no \`'GECKO:...'\` id anywhere in the source) rather than adopting RAVEN's own internal error IDs.

Found while writing a regression test for an unrelated fix (#449/#452) — reverting that fix to confirm the new test failed correctly surfaced this crash as a side effect.

## Test plan

- [x] Added `testReadDLKcatOutputUnrecognizedSubstrateErrorsCleanly_tc0035`, `testLoadDatabasesDuplicateUniprotEntriesErrorsCleanly_tc0036`, `testAddNewRxnsToECMissingGeneErrorsCleanly_tc0037`, `testGetSubsetEcModelMismatchedReactionsErrorsCleanly_tc0038` to `geckoCoreFunctionTests.m`.
- [x] Verified each new test fails against the pre-fix code — each one genuinely hits the `dispEM` crash (message contains `'dispEM'`), not a coincidental different failure — and passes against the fix.
- [x] Full local suite: 38/38 passed.

Closes #453.