### PR TITLE
feat: extract downloadKEGG.m and downloadUniProt.m as standalone functions

### DIFF
--- a/src/geckomat/get_enzyme_data/downloadKEGG.m
+++ b/src/geckomat/get_enzyme_data/downloadKEGG.m
@@ -1,0 +1,149 @@
+function downloadKEGG(keggID, filePath, keggGeneID)
+% downloadKEGG  Download a KEGG organism's gene data and write a CSV.
+%
+% Downloads gene information for every gene of a KEGG organism code, and
+% writes the result to a CSV file. Used by loadDatabases when its
+% expected kegg.tsv is missing; can also be called directly to refresh
+% one organism's KEGG snapshot without re-running loadDatabases for
+% everything else.
+%
+% Parameters
+% ----------
+% keggID : char
+%     KEGG organism code, e.g. 'sce' for Saccharomyces cerevisiae.
+% filePath : char
+%     destination CSV path (overwritten if it exists).
+% keggGeneID : char
+%     which KEGG gene identifier field becomes the output's gene-name
+%     column. 'kegg' (or empty, the default) uses the bare KEGG gene id;
+%     any other value is looked up as a cross-reference identifier on
+%     each KEGG entry (e.g. 'UniProt').
+%
+% Examples
+% --------
+%     downloadKEGG('sce', 'kegg.tsv', 'UniProt');
+%
+% See also
+% --------
+% loadDatabases, downloadUniProt
+
+if nargin < 3 || isempty(keggGeneID)
+    keggGeneID = 'kegg';
+end
+
+%% Download gene information
+webOptions = weboptions('Timeout',30);
+try
+    gene_list = webread(['http://rest.kegg.jp/list/' keggID],webOptions);
+catch ME
+    switch ME.identifier
+        case 'MATLAB:webservices:HTTP400StatusCodeError'
+            error(['Unable to download data form KEGG with a potentially invalid ID: ' keggID ])
+        otherwise
+            rethrow(ME)
+    end
+end
+gene_list = regexpi(gene_list, '[^\n]+','match')';
+gene_id   = regexpi(gene_list,['(?<=' keggID ':)\S+'],'match');
+
+% Retrieve information for every gene in the list, 10 genes per query
+genesPerQuery = 10;
+queries = ceil(numel(gene_id)/genesPerQuery);
+keggData  = cell(numel(gene_id),1);
+PB = progressReport(queries, ['Downloading KEGG data for organism code ' keggID]);
+for i = 1:queries
+    PB.count;
+    % Download batches of genes
+    firstIdx = i*genesPerQuery-(genesPerQuery-1);
+    lastIdx  = i*genesPerQuery;
+    if lastIdx > numel(gene_id) % Last query has probably less genes
+        lastIdx = numel(gene_id);
+    end
+    url      = ['http://rest.kegg.jp/get/' keggID ':' strjoin([gene_id{firstIdx:lastIdx}],['+' keggID ':'])];
+
+    % KEGG may be temporarily unresponsive, retry with exponential backoff
+    maxRetries = 5;
+    for attempt = 1:maxRetries
+        try
+            out = webread(url,webOptions);
+            break
+        catch ME
+            % A malformed or non-existing query will not succeed on retry
+            noRetry = ismember(ME.identifier,{'MATLAB:webservices:HTTP400StatusCodeError', ...
+                                              'MATLAB:webservices:HTTP404StatusCodeError'});
+            if noRetry || attempt == maxRetries
+                error(['Unable to download KEGG data (attempt %d of %d).\n' ...
+                       'URL: %s\n' ...
+                       'Check your internet connection and the status of the KEGG ' ...
+                       'REST API, then try again.\nOriginal error: %s'], ...
+                       attempt, maxRetries, url, ME.message);
+            end
+            pause(min(2^attempt,30)) % Wait 2, 4, 8 and 16 seconds before retrying
+        end
+    end
+    outSplit = strsplit(out,['///' 10]); %10 is new line character
+    if numel(outSplit) < lastIdx-firstIdx+2
+        error('KEGG returns less genes per query') %Reduce genesPerQuery
+    end
+    keggData(firstIdx:lastIdx) = outSplit(1:end-1);
+end
+
+%% Parsing of info to keggDB format
+% Entries returned by KEGG are separated by '///' followed by an empty line,
+% leaving a stray newline at the start of each entry after splitting. This
+% would break the startsWith(...,'ENTRY ') checks below, which detect entries
+% where the regular expression did not match and returned the entry unchanged
+keggData  = strtrim(keggData);
+
+sequence  = regexprep(keggData,'.*AASEQ\s+\d+\s+([A-Z\s])+?\s+NTSEQ.*','$1');
+%No AASEQ -> no protein -> not of interest
+noProt    = startsWith(sequence,'ENTRY ');
+uni       = regexprep(keggData,'.*UniProt: (\S+?)\s.*','$1');
+noUni     = startsWith(uni,'ENTRY ');
+uni(noProt | noUni)       = [];
+keggData(noProt | noUni) = [];
+sequence(noProt | noUni)  = [];
+sequence  = regexprep(sequence,'\s+','');
+keggGene  = regexprep(keggData,'ENTRY\s+(\S+?)\s.+','$1');
+
+switch keggGeneID
+    case {'kegg',''}
+        gene_name = keggGene;
+    otherwise
+        % In case there are special characters:
+        keggGeneIDT = regexptranslate('escape',keggGeneID);
+        gene_name = regexprep(keggData,['.+' keggGeneIDT ': (\S+?)\n.+'],'$1');
+        noID = ~contains(keggData,keggGeneIDT);
+        if all(noID)
+            error(['None of the KEGG entries are annotated with the gene identifier ' keggGeneID])
+        else
+            gene_name(noID)= [];
+            keggData(noID) = [];
+            keggGene(noID) = [];
+            sequence(noID) = [];
+            uni(noID)      = [];
+        end
+end
+
+EC_names  = regexprep(keggData,'.*ORTHOLOGY.*\[EC:(.*?)\].*','$1');
+EC_names(startsWith(EC_names,'ENTRY ')) = {''};
+
+MW = cell(numel(sequence),1);
+for i=1:numel(sequence)
+    if ~isempty(sequence{i})
+        MW{i} = num2str(round(calculateMW(sequence{i})));
+    end
+end
+
+pathway   = regexprep(keggData,'.*PATHWAY\s+(.*?)(BRITE|MODULE).*','$1');
+pathway(startsWith(pathway,'ENTRY ')) = {''};
+pathway   = strrep(pathway,[keggID '01100  Metabolic pathways'],'');
+pathway   = regexprep(pathway,'\n','');
+pathway   = regexprep(pathway,'           ','');
+
+out = [uni, gene_name, keggGene, EC_names, MW, pathway, sequence];
+out = cell2table(out);
+
+writetable(out, filePath, 'FileType', 'text', 'WriteVariableNames',false);
+fprintf('Model-specific KEGG database stored at %s\n',filePath);
+end

--- a/src/geckomat/get_enzyme_data/downloadUniProt.m
+++ b/src/geckomat/get_enzyme_data/downloadUniProt.m
@@ -1,0 +1,66 @@
+function downloadUniProt(uniprotID, filePath, geneIDfield, type, reviewed)
+% downloadUniProt  Download UniProt protein data for an organism and write a TSV.
+%
+% Downloads accession, gene name, EC number, mass and sequence for every
+% protein matching the given organism identifier, and writes the result
+% to a TSV file. Used by loadDatabases when its expected uniprot.tsv is
+% missing; can also be called directly to refresh one organism's UniProt
+% snapshot without re-running loadDatabases for everything else.
+%
+% Parameters
+% ----------
+% uniprotID : char
+%     UniProt-side identifier whose meaning depends on type, e.g. an NCBI
+%     taxonomy ID such as 559292 for Saccharomyces cerevisiae S288C.
+% filePath : char
+%     destination TSV path (overwritten if it exists).
+% geneIDfield : char
+%     UniProt field that becomes the second column (the gene matching
+%     key) (optional, default 'gene_oln', Ordered Locus Names, which
+%     works for most prokaryotes and budding yeast).
+% type : char
+%     UniProt query field for uniprotID (optional, default
+%     'taxonomy_id'). 'taxonomy' is accepted as an alias.
+% reviewed : logical
+%     whether to restrict the query to reviewed (Swiss-Prot) entries
+%     (optional, default true).
+%
+% Examples
+% --------
+%     downloadUniProt(559292, 'uniprot.tsv');
+%     downloadUniProt(559292, 'uniprot.tsv', 'gene_oln', 'taxonomy_id', true);
+%
+% See also
+% --------
+% loadDatabases, downloadKEGG
+
+if nargin < 3 || isempty(geneIDfield)
+    geneIDfield = 'gene_oln';
+end
+if nargin < 4 || isempty(type)
+    type = 'taxonomy_id';
+end
+if nargin < 5 || isempty(reviewed)
+    reviewed = true;
+end
+if strcmp(type,'taxonomy')
+    type = 'taxonomy_id';
+end
+if reviewed
+    uniprotRev = 'reviewed:true+AND+';
+else
+    uniprotRev = '';
+end
+
+disp(['Downloading Uniprot data for ' type ' ' num2str(uniprotID) '. This can take a few minutes.'])
+url = ['https://rest.uniprot.org/uniprotkb/stream?query=' uniprotRev ...
+       type ':' num2str(uniprotID) '&fields=accession%2C' geneIDfield ...
+    '%2Cec%2Cmass%2Csequence&format=tsv&compressed=false&sort=protein_name%20asc'];
+try
+    urlwrite(url,filePath,'Timeout',30);
+    fprintf('Model-specific UniProt database stored at %s\n',filePath);
+catch
+    error(['Download failed, check your internet connection and try again, or manually download: ' url ...
+        ' After downloading, store the file as ' filePath])
+end
+end

--- a/src/geckomat/get_enzyme_data/loadDatabases.m
+++ b/src/geckomat/get_enzyme_data/loadDatabases.m
@@ -28,7 +28,7 @@ function databases = loadDatabases(varargin)
 %
 % See also
 % --------
-% getECfromDatabase, loadBRENDAdata
+% getECfromDatabase, loadBRENDAdata, downloadKEGG, downloadUniProt
 
 p = parseGECKOargs(varargin, { ...
     'selectDatabase', 'both'; ...
@@ -49,15 +49,7 @@ uniprot.ID   = params.uniprot.ID;
 filePath    = fullfile(params.path,'data');
 uniprot.geneIDfield = params.uniprot.geneIDfield;
 uniprot.type = params.uniprot.type;
-if strcmp(uniprot.type,'taxonomy')
-    uniprot.type = 'taxonomy_id';
-end
 kegg.geneID = params.kegg.geneID;
-if params.uniprot.reviewed
-    uniprotRev = 'reviewed:true+AND+';
-else
-    uniprotRev = '';
-end
 
 warning('off', 'MATLAB:MKDIR:DirectoryExists');
 
@@ -71,17 +63,7 @@ if any(strcmp(selectDatabase,{'uniprot','both'}))
         if isempty(uniprot.ID)
             printOrange('WARNING: No uniprot.ID is specified, unable to download UniProt DB.\n');
         end
-        disp(['Downloading Uniprot data for ' uniprot.type ' ' uniprot.ID '. This can take a few minutes.'])
-        url = ['https://rest.uniprot.org/uniprotkb/stream?query=' uniprotRev ...
-               uniprot.type ':' num2str(uniprot.ID) '&fields=accession%2C' uniprot.geneIDfield ...
-            '%2Cec%2Cmass%2Csequence&format=tsv&compressed=false&sort=protein_name%20asc'];
-        try
-            urlwrite(url,uniprotPath,'Timeout',30);
-            fprintf('Model-specific UniProt database stored at %s\n',uniprotPath);
-        catch
-            error(['Download failed, check your internet connection and try again, or manually download: ' url ...
-                ' After downloading, store the file as ' uniprotPath])
-        end
+        downloadUniProt(uniprot.ID, uniprotPath, uniprot.geneIDfield, uniprot.type, params.uniprot.reviewed);
     end
     if exist(uniprotPath,'file')
         fid         = fopen(uniprotPath,'r');
@@ -131,120 +113,4 @@ if any(strcmp(selectDatabase,{'kegg','both'}))
         databases.kegg = [];
     end
 end
-end
-
-function downloadKEGG(keggID, filePath, keggGeneID)
-%% Download gene information
-webOptions = weboptions('Timeout',30);
-try
-    gene_list = webread(['http://rest.kegg.jp/list/' keggID],webOptions);
-catch ME
-    switch ME.identifier
-        case 'MATLAB:webservices:HTTP400StatusCodeError'
-            error(['Unable to download data form KEGG with a potentially invalid ID: ' keggID ])
-    end
-end
-gene_list = regexpi(gene_list, '[^\n]+','match')';
-gene_id   = regexpi(gene_list,['(?<=' keggID ':)\S+'],'match');
-
-% Retrieve information for every gene in the list, 10 genes per query
-genesPerQuery = 10;
-queries = ceil(numel(gene_id)/genesPerQuery);
-keggData  = cell(numel(gene_id),1);
-PB = progressReport(queries, ['Downloading KEGG data for organism code ' keggID]);
-for i = 1:queries
-    PB.count;
-    % Download batches of genes
-    firstIdx = i*genesPerQuery-(genesPerQuery-1);
-    lastIdx  = i*genesPerQuery;
-    if lastIdx > numel(gene_id) % Last query has probably less genes
-        lastIdx = numel(gene_id);
-    end
-    url      = ['http://rest.kegg.jp/get/' keggID ':' strjoin([gene_id{firstIdx:lastIdx}],['+' keggID ':'])];
-
-    % KEGG may be temporarily unresponsive, retry with exponential backoff
-    maxRetries = 5;
-    for attempt = 1:maxRetries
-        try
-            out = webread(url,webOptions);
-            break
-        catch ME
-            % A malformed or non-existing query will not succeed on retry
-            noRetry = ismember(ME.identifier,{'MATLAB:webservices:HTTP400StatusCodeError', ...
-                                              'MATLAB:webservices:HTTP404StatusCodeError'});
-            if noRetry || attempt == maxRetries
-                error(['Unable to download KEGG data (attempt %d of %d).\n' ...
-                       'URL: %s\n' ...
-                       'Check your internet connection and the status of the KEGG ' ...
-                       'REST API, then try again.\nOriginal error: %s'], ...
-                       attempt, maxRetries, url, ME.message);
-            end
-            pause(min(2^attempt,30)) % Wait 2, 4, 8 and 16 seconds before retrying
-        end
-    end
-    outSplit = strsplit(out,['///' 10]); %10 is new line character
-    if numel(outSplit) < lastIdx-firstIdx+2
-        error('KEGG returns less genes per query') %Reduce genesPerQuery
-    end
-    keggData(firstIdx:lastIdx) = outSplit(1:end-1);
-end
-
-%% Parsing of info to keggDB format
-% Entries returned by KEGG are separated by '///' followed by an empty line,
-% leaving a stray newline at the start of each entry after splitting. This
-% would break the startsWith(...,'ENTRY ') checks below, which detect entries
-% where the regular expression did not match and returned the entry unchanged
-keggData  = strtrim(keggData);
-
-sequence  = regexprep(keggData,'.*AASEQ\s+\d+\s+([A-Z\s])+?\s+NTSEQ.*','$1');
-%No AASEQ -> no protein -> not of interest
-noProt    = startsWith(sequence,'ENTRY ');
-uni       = regexprep(keggData,'.*UniProt: (\S+?)\s.*','$1');
-noUni     = startsWith(uni,'ENTRY ');
-uni(noProt | noUni)       = [];
-keggData(noProt | noUni) = [];
-sequence(noProt | noUni)  = [];
-sequence  = regexprep(sequence,'\s+','');
-keggGene  = regexprep(keggData,'ENTRY\s+(\S+?)\s.+','$1');
-
-switch keggGeneID
-    case {'kegg',''}
-        gene_name = keggGene;
-    otherwise
-        % In case there are special characters:
-        keggGeneIDT = regexptranslate('escape',keggGeneID);
-        gene_name = regexprep(keggData,['.+' keggGeneIDT ': (\S+?)\n.+'],'$1');
-        noID = ~contains(keggData,keggGeneIDT);
-        if all(noID)
-            error(['None of the KEGG entries are annotated with the gene identifier ' keggGeneID])
-        else
-            gene_name(noID)= [];
-            keggData(noID) = [];
-            keggGene(noID) = [];
-            sequence(noID) = [];
-            uni(noID)      = [];
-        end
-end
-
-EC_names  = regexprep(keggData,'.*ORTHOLOGY.*\[EC:(.*?)\].*','$1');
-EC_names(startsWith(EC_names,'ENTRY ')) = {''};
-
-MW = cell(numel(sequence),1);
-for i=1:numel(sequence)
-    if ~isempty(sequence{i})
-        MW{i} = num2str(round(calculateMW(sequence{i})));
-    end
-end
-
-pathway   = regexprep(keggData,'.*PATHWAY\s+(.*?)(BRITE|MODULE).*','$1');
-pathway(startsWith(pathway,'ENTRY ')) = {''};
-pathway   = strrep(pathway,[keggID '01100  Metabolic pathways'],'');
-pathway   = regexprep(pathway,'\n','');
-pathway   = regexprep(pathway,'           ','');
-
-out = [uni, gene_name, keggGene, EC_names, MW, pathway, sequence];
-out = cell2table(out);
-
-writetable(out, filePath, 'FileType', 'text', 'WriteVariableNames',false);
-fprintf('Model-specific KEGG database stored at %s\n',filePath);
 end


### PR DESCRIPTION
## Summary

`loadDatabases.m` carried the UniProt fetch inline and the KEGG fetch as a private local subfunction; both are now standalone, documented, independently-callable functions, matching geckopy's own `databases.kegg_download` / `databases.uniprot_download` split. Lets a user refresh one organism's KEGG or UniProt snapshot without re-running `loadDatabases` for everything else.

`loadDatabases.m` now just dispatches to these on cache miss — same auto-trigger behaviour as before (download only when the expected TSV is missing). Two small improvements picked up along the way:

- `downloadKEGG.m`: `keggGeneID` now defaults to `'kegg'` (matching its own documented meaning) when omitted, and an unexpected `webread` error (anything other than the already-handled HTTP 400) is rethrown instead of silently leaving `gene_list` undefined.
- `downloadUniProt.m`: the `'taxonomy'` → `'taxonomy_id'` alias now lives inside the function itself, so a standalone caller gets the same convenience `loadDatabases.m` already had.

No behaviour change to `loadDatabases.m`'s own call sites otherwise — same URLs, same parameters, same fall-through when `uniprot.ID`/`kegg.ID` is unset.

## Test plan

- [x] Not unit-tested: both functions' bodies are almost entirely a live network call (KEGG REST API / UniProt REST API), the same category as `runDLKcat.m`'s Docker dependency and the HTTP-calling majority of `submitOpenKineticsPredictor.m`/`fetchOpenKineticsPredictor.m` — none of which have automated coverage either.
- [x] Verified both files parse correctly (`nargin` introspection).
- [x] Full local suite: 40/40 passed with the extraction in place (no test exercises the actual download path — the one test touching `loadDatabases` hits its pre-existing-file branch, unaffected by this refactor).