### PR TITLE
fix: reconcile calculateMW with geckopy's calculate_mw

### DIFF
--- a/src/geckomat/get_enzyme_data/calculateMW.m
+++ b/src/geckomat/get_enzyme_data/calculateMW.m
@@ -2,6 +2,9 @@ function MW = calculateMW(sequence)
 % calculateMW  Calculate the molecular weight of a protein.
 %
 % Calculates the molecular weight of a protein from its amino acid sequence.
+% Matching is case-insensitive. Sequences with no recognized residue
+% (including an empty sequence) return NaN, rather than being mistaken for
+% an 18 Da protein.
 %
 % Parameters
 % ----------
@@ -12,7 +15,7 @@ function MW = calculateMW(sequence)
 % Returns
 % -------
 % MW : double
-%     the molecular weight number.
+%     the molecular weight number, or NaN if no residue was recognized.
 
 % A	Alanine
 % B	Aspartic acid or Asparagine
@@ -41,17 +44,40 @@ function MW = calculateMW(sequence)
 % Y	Tyrosine
 % Z	Glutamic acid or Glutamine
 
-aa_codes = {'A','B','C','D','E','F','G','H','I','J','K','L','M','N', ...
-            'O','P','Q','R','S','T','U','V','W','X','Y','Z'};
-aa_MWs   = [71.08 114.60 103.14 115.09 129.11 147.17 57.05 137.14 ...
-            113.16 113.16 128.17 113.16 131.20 114.10 255.31 97.12 ...
-            128.13 156.19 87.08 101.10 150.04 99.13 186.21 126.50 ...
-            163.17 128.62];
+% The 20 standard residues, individually sourced.
+aa_codes = {'A','C','D','E','F','G','H','I','K','L','M','N','P','Q','R', ...
+            'S','T','V','W','Y'};
+aa_MWs   = [71.08 103.14 115.09 129.11 147.17 57.05 137.14 113.16 128.17 ...
+            113.16 131.20 114.10 97.12 128.13 156.19 87.08 101.10 99.13 ...
+            186.21 163.17];
 
-MW = 18;
-for i = 1:length(aa_codes)
-    count = length(strfind(sequence,aa_codes{i}));
-    MW = MW + count*aa_MWs(i);
+% Ambiguous / non-standard codes, derived from the standard table above
+% rather than pre-rounded constants: B/Z average their two possible
+% residues, X averages across all 20 standard residues, J is Leu-or-Ile
+% (both 113.16, so either index gives the same value), O/U have no
+% standard-residue equivalent and keep their literature values.
+bMW = mean(aa_MWs(ismember(aa_codes,{'D','N'})));
+zMW = mean(aa_MWs(ismember(aa_codes,{'E','Q'})));
+xMW = mean(aa_MWs);
+jMW = aa_MWs(strcmp(aa_codes,'L'));
+
+allCodes = [aa_codes, {'B','J','O','U','X','Z'}];
+allMWs   = [aa_MWs, bMW, jMW, 255.31, 150.04, xMW, zMW];
+
+% Average mass of water (g/mol): the two H atoms and one OH that remain
+% after peptide bond condensation.
+waterMW = 18.01528;
+
+sequence = upper(sequence);
+MW = waterMW;
+nMatched = 0;
+for i = 1:length(allCodes)
+    count = length(strfind(sequence,allCodes{i}));
+    MW = MW + count*allMWs(i);
+    nMatched = nMatched + count;
+end
+if nMatched == 0
+    MW = NaN;
 end
 
 end

--- a/test/unit_tests/geckoCoreFunctionTests.m
+++ b/test/unit_tests/geckoCoreFunctionTests.m
@@ -1708,3 +1708,26 @@ function testMakeEcModelFallsBackToKeggForUnmatchedGenes_tc0044(testCase)
     verifyEqual(testCase, sum(strcmp(noUniprot,'G5')), 0)
 end
 
+
+function testCalculateMWReconciledWithGeckopy_tc0045(testCase)
+    % calculateMW used to disagree with geckopy's calculate_mw on the water
+    % mass, X and B's residue masses, case-sensitivity, and the
+    % no-recognized-residue return value; reconciled to match geckopy on
+    % all four (raven-gecko-parity#11): water 18.01528 (was 18); X and B
+    % computed as the mean of their possible standard residues (was
+    % pre-rounded constants 126.50/114.60); case-insensitive (was
+    % case-sensitive, silently ignoring lowercase); NaN, not 18, when no
+    % residue is recognized.
+    verifyTrue(testCase, isnan(calculateMW('')))
+    verifyTrue(testCase, isnan(calculateMW('123 ---')))
+    % X: mean of the 20 standard residues (118.885) + water.
+    verifyEqual(testCase, calculateMW('X'), 136.90028, 'AbsTol', 1e-9)
+    % B: mean(D,N) = 114.595 + water.
+    verifyEqual(testCase, calculateMW('B'), 132.61028, 'AbsTol', 1e-9)
+    % Case-insensitive: all four letters count as 'A', not just the two
+    % uppercase ones.
+    verifyEqual(testCase, calculateMW('AaAa'), 302.33528, 'AbsTol', 1e-9)
+    % The 20 standard residues once each, plus the water constant only.
+    verifyEqual(testCase, calculateMW('ACDEFGHIKLMNPQRSTVWY'), 2395.71528, 'AbsTol', 1e-9)
+end
+


### PR DESCRIPTION
Reconciles four divergences between `calculateMW.m` and geckopy's `calculate_mw`, all resolved in favor of geckopy's behavior:

- water mass: `18.01528` (was the rounded `18`)
- `X` and `B` masses: computed as the mean of their possible standard residues, rather than pre-rounded historical constants (`X`: mean of all 20 standard residues, was `126.50`; `B`: mean of `D` and `N`, was `114.60`)
- case-insensitive matching (was case-sensitive, silently ignoring lowercase letters)
- `NaN`, not `18`, for a sequence with no recognized residue (including an empty sequence)

New test `testCalculateMWReconciledWithGeckopy_tc0045` asserts all five reproducer cases from the linked issue; confirmed it fails against the pre-fix code before restoring the fix.

Addresses SysBioChalmers/raven-gecko-parity#11.