### PR TITLE
docs: clarify calculateMW and reportEnzymeUsage docstrings

### DIFF
--- a/src/geckomat/get_enzyme_data/calculateMW.m
+++ b/src/geckomat/get_enzyme_data/calculateMW.m
@@ -15,7 +15,7 @@ function MW = calculateMW(sequence)
 % Returns
 % -------
 % MW : double
-%     the molecular weight number, or NaN if no residue was recognized.
+%     the molecular weight in Da, or NaN if no residue was recognized.
 
 % A	Alanine
 % B	Aspartic acid or Asparagine

--- a/src/geckomat/utilities/reportEnzymeUsage.m
+++ b/src/geckomat/utilities/reportEnzymeUsage.m
@@ -1,7 +1,8 @@
 function usageReport = reportEnzymeUsage(ecModel, usageData, varargin)
 % reportEnzymeUsage  Summarize the results from enzymeUsage.
 %
-% Summarizes the results from enzymeUsage.
+% Ranks the enzymes from enzymeUsage into two tables: those with the
+% highest capacity usage, and those with the highest absolute usage.
 %
 % Parameters
 % ----------
@@ -13,17 +14,23 @@ function usageReport = reportEnzymeUsage(ecModel, usageData, varargin)
 % Name-Value Arguments
 % --------------------
 % highCapUsage : double
-%     minimum ratio of enzyme capacity usage to be considered as high usage
-%     (default 0.9, referring to a minimum of 90% capacity usage).
+%     minimum fraction of enzyme capacity usage to be listed as high usage
+%     (default 0.9, i.e. at least 90% capacity usage).
 % topAbsUsage : double
-%     number of top enzymes with highest absolute usage (default 10,
-%     returning the top 10 enzymes with highest absolute usage. With Inf or
-%     0, all enzymes are returned).
+%     how many top enzymes by absolute usage to list (default 10). Use 0
+%     or Inf to list all enzymes instead. Enzymes whose reactions carry no
+%     flux are never listed here, as they do not contribute to the
+%     solution.
 %
 % Returns
 % -------
-% usageReport : table
-%     table with summary information.
+% usageReport : struct
+%     highCapUsage : table
+%         enzymes at or above the highCapUsage threshold.
+%     topAbsUsage : table
+%         the topAbsUsage enzymes with the highest absolute usage.
+%     totalUsageFlux : double
+%         total protein pool used, i.e. the upper bound of prot_pool_exchange.
 %
 % Examples
 % --------


### PR DESCRIPTION
Small follow-up to #459 and #460 (both already merged): tightens the
docstrings on the two touched functions so the output is clear to an
end-user without needing to read the implementation.

- **calculateMW**: states the unit of the returned molecular weight (Da).
- **reportEnzymeUsage**:
  - drops the summary line that just repeated the one-line header
  - rewrites the `highCapUsage`/`topAbsUsage` descriptions to be more direct
  - documents that `topAbsUsage` never lists enzymes with no flux-carrying
    reactions (the behavior added in #460)
  - fixes the `Returns` section, which said `usageReport : table with
    summary information` even though `usageReport` is a struct with two
    tables (`highCapUsage`, `topAbsUsage`) and a scalar (`totalUsageFlux`)

No functional changes -- comment/docstring only.