### PR TITLE
docs: audit and clarify all function docstrings

### DIFF
--- a/src/geckomat/change_model/applyComplexData.m
+++ b/src/geckomat/change_model/applyComplexData.m
@@ -27,11 +27,23 @@ function [model, foundComplex, proposedComplex] = applyComplexData(model, vararg
 %     ecModel where model.ec.rxnEnzMat is populated with subunit
 %     stochiometries.
 % foundComplex : table
-%     complexes that fully matched between the model and the complex data.
+%     complexes that fully matched between the model and the complex data
+%     (columns described under Notes).
 % proposedComplex : table
 %     complexes where the model contained >75% but <100% of the proteins
 %     indicated by Complex Portal, or where the model contained more
-%     proteins than indicated for that complex in Complex Portal.
+%     proteins than indicated for that complex in Complex Portal (same
+%     columns as foundComplex, plus a percentage match column).
+%
+% Notes
+% -----
+% foundComplex and proposedComplex share the following columns: rxn
+% (reaction identifier), complexID and name (Complex Portal identifiers),
+% genes (gene names of the complex subunits), protID_model (matched protein
+% IDs from the model), protID_complex (protein IDs listed by Complex
+% Portal), and stochiometry (subunit stoichiometry from Complex Portal).
+% proposedComplex has an additional match column with the percentage match
+% between the model proteins and the proposed complex.
 %
 % Examples
 % --------

--- a/src/geckomat/change_model/applyCustomKcats.m
+++ b/src/geckomat/change_model/applyCustomKcats.m
@@ -27,9 +27,12 @@ function [model, rxnUpdated, notMatch] = applyCustomKcats(model, varargin)
 % rxnUpdated : cell
 %     ids list of updated reactions, where new kcats were applied.
 % notMatch : table
-%     table with the list of reactions for which the custom information
-%     provided does not have full match (> 50%) based on GPR rules. These
-%     are suggested to be curated by the user.
+%     reactions for which the custom information provided has a partial
+%     match (at least 50%, but not 100%) with the reaction's GPR rule, for
+%     the user to curate manually. Columns: rxns and name (reaction
+%     identifier and name), custom enzymes (the proteins specified in
+%     customKcats), enzymes in model (the enzymes annotated to the reaction
+%     in the model), and rules (the reaction's GPR rule).
 %
 % Notes
 % -----

--- a/src/geckomat/change_model/findMetSmiles.m
+++ b/src/geckomat/change_model/findMetSmiles.m
@@ -1,10 +1,9 @@
 function [model,noSMILES] = findMetSmiles(model, varargin)
 % findMetSmiles  Query PubChem by metabolite names to obtain SMILES.
 %
-% Queries PubChem by metabolite names to obtain SMILES. Matches will also
-% be stored in tutorials/***/data/smilesDB.tsv, that will also be queried
-% first next time the function is run. If the model already has a metSmiles
-% field, then non-empty entries will not be overwritten.
+% Matches are cached in tutorials/***/data/smilesDB.tsv, which is checked
+% first on subsequent runs so repeated queries are avoided. If the model
+% already has a metSmiles field, non-empty entries are left unchanged.
 %
 % Parameters
 % ----------

--- a/src/geckomat/change_model/makeEcModel.m
+++ b/src/geckomat/change_model/makeEcModel.m
@@ -28,7 +28,8 @@ function [model, noUniprot] = makeEcModel(model, varargin)
 %     draw reactions are added to the model, but their usage is not yet
 %     implemented (due to absent kcat values at this stage).
 % noUniprot : cell
-%     genes for which no information could be found in the Uniprot database.
+%     genes for which no information could be found in either the Uniprot
+%     or, as fallback, the KEGG database.
 %
 % Notes
 % -----
@@ -46,6 +47,8 @@ function [model, noUniprot] = makeEcModel(model, varargin)
 %     values. For geckoLight the structure is different, where each reaction
 %     can have multiple isozymes.
 % 7.  Add enzyme information fields to model.ec structure: MW, sequence.
+%     Data is gathered from UniProt, with KEGG used as a fallback for genes
+%     that UniProt does not match.
 % 8.  Populate model.ec structure with information from each reaction.
 % 9.  [Skipped with geckoLight:] Add proteins as pseudometabolites.
 % 10. Add prot_pool pseudometabolite.
@@ -69,7 +72,9 @@ function [model, noUniprot] = makeEcModel(model, varargin)
 % - notes : notes that can be set by downstream functions - not set here.
 % - eccodes : enzyme codes for each enzyme - not set here.
 % - genes : the genes involved in the kcats - not necessarily the same as model.genes, since some genes may not be found in databases etc.
-% - enzymes : Uniprot protein identifiers for the genes.
+% - enzymes : Uniprot protein identifiers for the genes; for a gene that
+%   was only matched via the KEGG fallback and has no UniProt accession on
+%   its KEGG entry, the bare KEGG gene identifier is used instead.
 % - mw : molecular weights of the enzymes.
 % - sequence : sequence of the genes/enzymes.
 % - concs : concentrations of the enzymes - not set here.

--- a/src/geckomat/gather_kcats/fuzzyKcatMatching.m
+++ b/src/geckomat/gather_kcats/fuzzyKcatMatching.m
@@ -39,10 +39,10 @@ function kcatList = fuzzyKcatMatching(model, varargin)
 %
 % - source : 'brenda'.
 % - rxns : reaction identifiers.
-% - substrate : substrate names.
-% - kcat : proposed kcat value in /sec.
+% - substrates : substrate names.
+% - kcats : proposed kcat value in /sec.
 % - eccodes : as used to query BRENDA.
-% - wildCardLvl : which level of EC wild-card was necessary to find a match
+% - wildcardLvl : which level of EC wild-card was necessary to find a match
 %   (0: w.x.y.z; 1: w.x.y.-; 2: w.x.-.-; 3: w.-.-.-).
 % - origin : which level of specificity was necessary to find a match
 %   (1: correct organism, correct substrate, kcat; 2: any organism, correct
@@ -366,7 +366,7 @@ function [kcat,matches] = matchKcat(EC,subs,substrCoeff,KCATcell,organism,...
     org_index,SAcell,KCATcellMatches,SAcellMatches)
 
 %Will go through BRENDA and will record any match. Afterwards, it will
-%return the average value and the number of matches attained.
+%return the maximum value and the number of matches attained.
 kcat    = [];
 matches = 0;
 

--- a/src/geckomat/gather_kcats/mergeDLKcatAndFuzzyKcats.m
+++ b/src/geckomat/gather_kcats/mergeDLKcatAndFuzzyKcats.m
@@ -39,7 +39,10 @@ function mergedKcatList = mergeDLKcatAndFuzzyKcats(kcatListDLKcat, kcatListFuzzy
 % Returns
 % -------
 % mergedKcatList : struct
-%     merged list of kcats.
+%     merged kcatList with the same field layout produced by mergeKcats
+%     (source, kcatSource, rxns, genes, substrates, kcats, eccodes,
+%     wildcardLvl, origin), keeping only the rows selected by the order of
+%     preference above.
 %
 % Notes
 % -----

--- a/src/geckomat/gather_kcats/mergeKcats.m
+++ b/src/geckomat/gather_kcats/mergeKcats.m
@@ -45,14 +45,26 @@ function mergedKcatList = mergeKcats(kcatLists, sourcePriority, varargin)
 % Returns
 % -------
 % mergedKcatList : struct
-%     merged kcatList. Per-row provenance is preserved verbatim in the
-%     kcatSource field; the scalar source field is set to 'merged'. Row
-%     order follows the order of the input lists (each list's surviving
-%     rows, in turn), so a two-list call behaves like the legacy
-%     mergeDLKcatAndFuzzyKcats.
+%     merged kcatList, keeping only the winning rows per reaction; see
+%     Notes below for its fields. Row order follows the order of the input
+%     lists (each list's surviving rows, in turn), so a two-list call
+%     behaves like the legacy mergeDLKcatAndFuzzyKcats.
 %
 % Notes
 % -----
+% The mergedKcatList structure has the following fields:
+%
+% - source : 'merged'.
+% - kcatSource : per-row provenance, preserved verbatim from the input
+%   lists.
+% - rxns : reaction identifiers.
+% - genes : gene identifiers (where provided by the input lists).
+% - substrates : substrate names (where provided by the input lists).
+% - kcats : selected kcat value in /sec.
+% - eccodes : as used to query BRENDA (where applicable).
+% - wildcardLvl : wildcard level of the source match (where applicable).
+% - origin : specificity level of the source match (where applicable).
+%
 % The origin parameter:
 %
 % - 1 : correct organism, correct substrate, kcat.

--- a/src/geckomat/gather_kcats/readDLKcatOutput.m
+++ b/src/geckomat/gather_kcats/readDLKcatOutput.m
@@ -30,8 +30,8 @@ function kcatList = readDLKcatOutput(model, varargin)
 % - source : 'DLKcat'.
 % - rxns : reaction identifiers.
 % - genes : gene identifiers.
-% - substrate : substrate names.
-% - kcat : predicted kcat value in /sec.
+% - substrates : substrate names.
+% - kcats : predicted kcat value in /sec.
 %
 % Examples
 % --------

--- a/src/geckomat/gather_kcats/runDLKcat.m
+++ b/src/geckomat/gather_kcats/runDLKcat.m
@@ -1,10 +1,10 @@
 function runDLKcat(varargin)
 % runDLKcat  Run DLKcat to predict kcat values from a Docker image.
 %
-% Runs DLKcat to predict kcat values from a Docker image. Once DLKcat is
-% successfully run, the DLKcat file will be overwritten with the DLKcat
-% output in the model-specific 'data' sub-folder taken from modelAdapter
-% (e.g. GECKO/tutorials/tutorial_yeast-GEM/data/DLKcat.tsv).
+% Runs DLKcat via a Docker image; once it completes successfully, the
+% DLKcat file is overwritten with the predicted output, in the model-
+% specific 'data' sub-folder taken from modelAdapter (e.g.
+% GECKO/tutorials/tutorial_yeast-GEM/data/DLKcat.tsv).
 %
 % Name-Value Arguments
 % --------------------

--- a/src/geckomat/gather_kcats/selectKcatValue.m
+++ b/src/geckomat/gather_kcats/selectKcatValue.m
@@ -17,10 +17,10 @@ function [model, rxnIdx] = selectKcatValue(model,kcatList,varargin)
 %     following fields:
 %
 %     - source : e.g. 'DLKcat' or 'gotenzymes'.
-%     - rxns : reaction identifiers, matching model.rxns.
-%     - genes : gene identifiers, matching model.genes.
-%     - substrate : substrates, matching model.mets.
-%     - kcat : predicted kcat value in /sec.
+%     - rxns : reaction identifiers, matching model.ec.rxns.
+%     - genes : gene identifiers, matching model.ec.genes.
+%     - substrates : substrate names, matching model.metNames.
+%     - kcats : predicted kcat value in /sec.
 %
 % Name-Value Arguments
 % --------------------

--- a/src/geckomat/get_enzyme_data/calculateMW.m
+++ b/src/geckomat/get_enzyme_data/calculateMW.m
@@ -15,7 +15,7 @@ function MW = calculateMW(sequence)
 % Returns
 % -------
 % MW : double
-%     the molecular weight number, or NaN if no residue was recognized.
+%     the molecular weight in Da, or NaN if no residue was recognized.
 
 % A	Alanine
 % B	Aspartic acid or Asparagine

--- a/src/geckomat/get_enzyme_data/findECInDB.m
+++ b/src/geckomat/get_enzyme_data/findECInDB.m
@@ -1,7 +1,13 @@
 function [EC,conflicts] = findECInDB(gene_set, DBecNum, DBMW, geneIndex, geneHashMap)
-% findECInDB  Collect enzyme codes for genes from the UniProt or KEGG database.
+% findECInDB  Look up EC numbers for a reaction's gene set in a UniProt or KEGG index.
 %
-% Collects enzyme codes for genes from the UniProt or KEGG database.
+% For each gene, finds its matching database entries and takes the EC number
+% of the lightest-weight matching protein when a single EC number applies to
+% that gene; genes with several distinct EC numbers among their matches are
+% also reported as conflicts (the first match is still used for EC). When
+% gene_set has more than one gene (an enzyme complex), the numbers found for
+% each gene are combined by intersection where they share a match (wildcards
+% such as "-" are accounted for), otherwise by union.
 %
 % Parameters
 % ----------
@@ -19,7 +25,8 @@ function [EC,conflicts] = findECInDB(gene_set, DBecNum, DBMW, geneIndex, geneHas
 % Returns
 % -------
 % EC : char
-%     all EC numbers found for the genes in gene_set.
+%     EC numbers that apply to gene_set, each prefixed with "EC" and
+%     separated by ";" (e.g. "EC1.1.1.1;EC1.1.1.2").
 % conflicts : cell
 %     genes with multiple protein matches.
 %

--- a/src/geckomat/get_enzyme_data/loadBRENDAdata.m
+++ b/src/geckomat/get_enzyme_data/loadBRENDAdata.m
@@ -8,9 +8,8 @@ function [KCATcell, SAcell] = loadBRENDAdata(varargin)
 % molecular weights).
 %
 % kcat.tsv and sa.tsv each carry both a max and a median aggregate per
-% (EC, substrate, organism) triple; only the max column is used here,
-% matching this function's previous, single-aggregate behaviour. The three
-% files are produced by the `geckopy brenda-refresh` CLI (see geckopy's
+% (EC, substrate, organism) triple; only the max column is used here. The
+% three files are produced by the `geckopy brenda-refresh` CLI (see geckopy's
 % databases.brenda_loader for the Python-side reader of the same files) and
 % each starts with a `#`-prefixed release-version line followed by a
 % tab-delimited column header, both skipped on read.

--- a/src/geckomat/kcat_sensitivity_analysis/Bayesian/abc_max.m
+++ b/src/geckomat/kcat_sensitivity_analysis/Bayesian/abc_max.m
@@ -1,8 +1,8 @@
 function [rmse,rmseList] = abc_max(ecModel,bayData,varargin)
 % abc_max  Average RMSE for a set of growth data and kcats.
 %
-% Internal function in bayesianSensitivityTuning. Gets the average RMSE for a
-% certain set of growth data and kcats.
+% Internal helper used by bayesianSensitivityTuning to score one ecModel
+% (with a given set of kcats) against the experimental growth and flux data.
 %
 % Parameters
 % ----------

--- a/src/geckomat/kcat_sensitivity_analysis/Bayesian/bayesianSensitivityTuning.m
+++ b/src/geckomat/kcat_sensitivity_analysis/Bayesian/bayesianSensitivityTuning.m
@@ -1,14 +1,16 @@
 function [ecModel, rmseTrace, kcatTrace, sigmaLogTrace, diagnostics, posteriorSamples, prunedModel] = bayesianSensitivityTuning(ecModel,varargin)
 % bayesianSensitivityTuning  ABC-SMC Bayesian tuning of ecModel kcat values.
 %
-% Performs an iterative ABC-SMC Bayesian parameter-estimation procedure that
-% searches for kcat values which allow an ecModel to match experimental flux
-% data. It repeatedly proposes new sets of kcats, simulates the ecModel with
-% each set, measures the discrepancy (RMSE) between predicted and observed
-% growth/fluxes, and then keeps only the best-performing samples. Over
-% generations, it gradually narrows the acceptable region and adapts the
-% proposal distribution - learning correlations between kcats - until it
-% converges on a posterior distribution of plausible kcat values.
+% Performs an iterative ABC-SMC (Approximate Bayesian Computation Sequential
+% Monte Carlo) procedure that searches for kcat values which let an ecModel
+% match experimental growth rates and exchange fluxes. Each generation
+% samples new kcat sets, simulates the ecModel with FBA, scores each set by
+% RMSE against the experimental data, and keeps only the best-performing
+% samples to guide the next generation's sampling. Kcats from high-confidence
+% sources (e.g. BRENDA) are shrunk back toward their prior unless the data
+% strongly supports a change, while kcats from more uncertain sources (e.g.
+% DLKcat) are allowed to move further. The procedure stops once the best
+% RMSE drops below rmseThreshold or maxGenerations is reached.
 %
 % Parameters
 % ----------
@@ -40,7 +42,10 @@ function [ecModel, rmseTrace, kcatTrace, sigmaLogTrace, diagnostics, posteriorSa
 % sigmaLogTrace : double
 %     history of posterior sigmaLog per generation.
 % diagnostics : struct
-%     detailed diagnostics structure.
+%     per-generation diagnostics for inspecting convergence, including
+%     acceptance rates, shrinkage weights, RMSE and parameter-diversity
+%     statistics, per-source breakdowns, and (when pruning is enabled) a
+%     pruning report.
 % posteriorSamples : struct
 %     final generation's accepted samples.
 % prunedModel : struct
@@ -49,50 +54,10 @@ function [ecModel, rmseTrace, kcatTrace, sigmaLogTrace, diagnostics, posteriorSa
 %
 % Notes
 % -----
-% How it works:
-%
-% 1. INITIALIZATION: Starts with prior kcat values from databases (BRENDA,
-%    DLKcat) or user-defined values, each with an associated uncertainty.
-% 2. SAMPLING: At each generation, proposes new kcat sets by sampling from
-%    distributions centered on the current best values. Early generations
-%    explore broadly; later generations refine around high-quality solutions.
-% 3. EVALUATION: For each proposed kcat set, runs flux balance analysis (FBA)
-%    to simulate the model and computes RMSE against experimental data:
-%    (a) maximum growth rates from literature; (b) exchange fluxes
-%    (uptake/secretion rates) from literature.
-% 4. SELECTION: Accepts the best-performing samples (lowest RMSE) and uses
-%    them to guide the next generation's sampling. Poor samples are discarded.
-% 5. CONVERGENCE: Over generations (~50-100), the algorithm narrows the
-%    search space around parameter values that fit data well, learns
-%    correlations between parameters (low-rank covariance structure), applies
-%    source-specific constraints (e.g. trusted BRENDA values stay closer to
-%    prior than uncertain DLKcat predictions), and enforces sparsity
-%    (parameters with weak evidence snap back to prior).
-% 6. OUTPUT: Returns the best kcat set, plus the full posterior distribution
-%    for uncertainty quantification and an optional pruned model where
-%    insignificant parameter changes are reverted to prior values.
-%
 % The posteriorSamples structure has the following fields:
 %
 % - kcats : matrix of all accepted kcat sets.
 % - rmse : vector of corresponding RMSE values.
-%
-% Biological validation: the algorithm finds kcat values that allow the model
-% to accurately predict organism growth rate under specific media conditions
-% and carbon source utilization and metabolite secretion patterns. These
-% predictions are validated against independent experimental measurements
-% from the literature, ensuring the model reflects real biological behavior.
-%
-% Key features:
-%
-% - Respects prior knowledge: parameters with high-confidence priors (BRENDA
-%   measurements, user-validated values) change only with strong evidence.
-% - Handles uncertainty: uncertain predictions (DLKcat) are allowed to
-%   deviate more freely to match experimental data.
-% - Avoids overfitting: sparsity constraints and variance caps prevent
-%   excessive parameter changes that don't improve model fit.
-% - Provides uncertainty: returns full posterior distribution, not just point
-%   estimates, enabling ensemble predictions and confidence intervals.
 %
 % Examples
 % --------
@@ -766,7 +731,9 @@ function [prunedModel, pruningReport] = pruneInsignificantKcats(ecModel, kcat0, 
 %
 % OUTPUTS
 %   prunedModel     ecModel with insignificant kcats snapped back to prior
-%   pruningReport   Struct with detailed pruning results
+%   pruningReport   Struct summarizing which kcats were pruned vs. kept
+%                   (counts and indices, overall and by source), and the
+%                   RMSE before and after pruning
 
 fprintf('\n=== Post-Optimization Sensitivity Analysis ===\n');
 

--- a/src/geckomat/kcat_sensitivity_analysis/findMaxValue.m
+++ b/src/geckomat/kcat_sensitivity_analysis/findMaxValue.m
@@ -1,9 +1,9 @@
 function [value,organism,parameter] = findMaxValue(EC_cell,BRENDA,SA_cell)
 % findMaxValue  Get the maximum kinetic parameter for a set of EC numbers.
 %
-% Gets the maximum kinetic parameter (Kcat or S.A.*Mw) from the BRENDA files
-% for the specified set of EC numbers. The algorithm also returns the
-% organism and the parameter type (Kcat or S.A.) of the query.
+% Searches the BRENDA kcat and specific-activity (S.A.*Mw) data for the given
+% EC numbers and returns the largest value found, together with the organism
+% it came from and which parameter type (Kcat or S.A.) it is.
 %
 % Parameters
 % ----------

--- a/src/geckomat/kcat_sensitivity_analysis/sensitivityTuning.m
+++ b/src/geckomat/kcat_sensitivity_analysis/sensitivityTuning.m
@@ -1,8 +1,9 @@
 function [model, tunedKcats] = sensitivityTuning(model, varargin)
 % sensitivityTuning  Relax the most limiting kcats to reach a growth rate.
 %
-% Relaxes the most limiting kcats until a certain growth rate is reached. The
-% function will update kcats in model.ec.kcat.
+% Iteratively increases the kcat of whichever enzyme currently limits growth
+% the most, until the model reaches the desired growth rate, updating the
+% tuned values in model.ec.kcat.
 %
 % Parameters
 % ----------
@@ -41,6 +42,8 @@ function [model, tunedKcats] = sensitivityTuning(model, varargin)
 %   kcat value has been tuned.
 % - oldKcat : kcat values in the input model.
 % - newKcat : kcat values in the output model, after tuning.
+% - source : source label of each kcat, taken from the input model before
+%   tuning.
 %
 % The model.ec.notes field will contain the original kcat value and source,
 % unless the kcat has previously been set by sensitivityTuning, in which case

--- a/src/geckomat/kcat_sensitivity_analysis/sigmaFitter.m
+++ b/src/geckomat/kcat_sensitivity_analysis/sigmaFitter.m
@@ -1,9 +1,9 @@
 function [model, sigma] = sigmaFitter(model, varargin)
 % sigmaFitter  Fit the average enzyme saturation factor of an ecModel.
 %
-% Fits the average enzyme saturation factor in an ecModel according to a
-% provided experimentally measured value for the objective function (i.e.
-% growth rate at specified conditions).
+% Scans candidate sigma-factors from 0.01 to 1 in steps of 0.01 and picks the
+% one whose simulated growth rate best matches the provided experimental
+% growth rate, then applies it to the model's protein pool constraint.
 %
 % Parameters
 % ----------

--- a/src/geckomat/kcat_sensitivity_analysis/truncateValues.m
+++ b/src/geckomat/kcat_sensitivity_analysis/truncateValues.m
@@ -1,8 +1,8 @@
 function table = truncateValues(table,cols)
 % truncateValues  Round values in selected columns to six significant digits.
 %
-% Rounds the values in the specified columns of a cell array or table,
-% keeping six significant digits per value based on its order of magnitude.
+% Rounds each value in the given columns of a cell array or table to six
+% significant digits, based on the value's order of magnitude.
 %
 % Parameters
 % ----------

--- a/src/geckomat/limit_proteins/getConcControlCoeffs.m
+++ b/src/geckomat/limit_proteins/getConcControlCoeffs.m
@@ -1,7 +1,12 @@
 function [enz, controlCoeffs] = getConcControlCoeffs(model, varargin)
 % getConcControlCoeffs  Calculate control coefficients of protein usage.
 %
-% Calculate control coefficients of protein usage.
+% For each candidate protein whose usage reaction is running above the
+% given limit fraction of its upper bound, temporarily increases that
+% protein's usage upper bound by foldChange, re-solves, and expresses the
+% resulting growth-rate increase per unit of concentration increase as a
+% control coefficient. Proteins below the limit, or whose increase does
+% not measurably raise growth, get a coefficient of zero.
 %
 % Parameters
 % ----------
@@ -16,15 +21,19 @@ function [enz, controlCoeffs] = getConcControlCoeffs(model, varargin)
 % foldChange : double
 %     a value how much to increase the protein concentration (default 2).
 % limit : double
-%     a value to determine limiting protein usage reactions, calculated as
-%     usage/concentration (default 0).
+%     threshold on the usage/concentration ratio (how saturated a
+%     protein's usage upper bound already is); only proteins with a ratio
+%     above this value are evaluated for a control coefficient (default
+%     0, i.e. any nonzero usage is evaluated).
 %
 % Returns
 % -------
 % enz : logical
-%     a logical vector of enzymes analyzed.
+%     flags which of the input proteins had a usage/concentration ratio
+%     above limit and were evaluated for a control coefficient.
 % controlCoeffs : double
-%     a vector array with the coefficients.
+%     control coefficient per input protein (0 for proteins not evaluated
+%     or whose increase did not measurably raise growth).
 %
 % Examples
 % --------

--- a/src/geckomat/limit_proteins/relaxProteomicsGreedy.m
+++ b/src/geckomat/limit_proteins/relaxProteomicsGreedy.m
@@ -44,22 +44,16 @@ function result = relaxProteomicsGreedy(model, varargin)
 %
 % Notes
 % -----
-% Ported from geckopy's relax_proteomics_greedy
-% (limit_proteins/relax_proteomics_greedy.py), itself ported from the
-% legacy geckopy package (Carrasco et al., 2023,
-% https://doi.org/10.1128/spectrum.01705-23),
-% geckopy/experimental/relaxation.py.
-%
 % Different relaxation strategy from flexibilizeEnzConcs: this one is
 % shadow-price-ordered (one solve per step) and often converges in fewer
 % iterations when one or two enzymes dominate the infeasibility. The
 % trade-off is that it fully unconstrains each picked enzyme with no
 % tighten-back pass, so the result is looser (less proteomics-faithful).
 %
-% Two distinct non-convergence outcomes, matching the Python side exactly:
-% running out of eligible candidates before reaching minimalGrowth returns
-% normally with converged=false; exhausting maxIterations while candidates
-% still remained raises an error instead.
+% There are two distinct non-convergence outcomes: running out of
+% eligible candidates before reaching minimalGrowth returns normally with
+% converged=false; exhausting maxIterations while candidates still
+% remained raises an error instead.
 %
 % See also
 % --------

--- a/src/geckomat/limit_proteins/updateProtPool.m
+++ b/src/geckomat/limit_proteins/updateProtPool.m
@@ -1,13 +1,15 @@
 function ecModel  = updateProtPool(ecModel, varargin)
 % updateProtPool  Update the protein pool to compensate for proteomics.
 %
-% Obsolete since GECKO 3.2.0, as all (measured and unmeasured) enzymes are
-% drawn from the protein pool. Instead, use setProtPoolSize. See
-% https://github.com/SysBioChalmers/GECKO/issues/375 for explanation.
-%
-% Before GECKO 3.2.0: updates the protein pool to compensate for measured
-% proteomics data (in model.ec.concs), as only the unmeasured enzymes draw
-% from the protein pool.
+% Only applicable to ecModels where unmeasured enzymes draw from the
+% protein pool while measured enzymes (constrained via model.ec.concs) do
+% not: shrinks the protein pool exchange upper bound so it represents only
+% the remaining, unmeasured protein content (total protein content Ptot
+% minus the measured protein mass). For ecModels generated with GECKO
+% 3.2.0 or later, where all enzymes draw from the protein pool regardless
+% of whether they are measured, this function raises an error instead;
+% use setProtPoolSize (see
+% https://github.com/SysBioChalmers/GECKO/issues/375).
 %
 % Parameters
 % ----------
@@ -27,8 +29,8 @@ function ecModel  = updateProtPool(ecModel, varargin)
 % Returns
 % -------
 % ecModel : struct
-%     an ecModel where model.ec.concs is populated with protein
-%     concentrations.
+%     an ecModel where the protein pool exchange reaction's upper bound
+%     has been reduced to reflect only the unmeasured protein content.
 %
 % Examples
 % --------

--- a/src/geckomat/utilities/enzymeUsage.m
+++ b/src/geckomat/utilities/enzymeUsage.m
@@ -11,9 +11,8 @@ function usageData = enzymeUsage(ecModel,fluxes,varargin)
 %    concentration was not constrained in the model);
 % 3. UB: the upper bound of each enzyme exchange reaction, which may not be
 %    the same as the enzyme concentration, if it has been flexibilized;
-% 4. protID: the protein identifiers for each enzyme (if the model has an
-%    enzymes field then this order is used, otherwise it is given
-%    alphabetically).
+% 4. protID: the protein identifiers for each enzyme, in the same order as
+%    ecModel.ec.enzymes.
 %
 % Parameters
 % ----------

--- a/src/geckomat/utilities/findGECKOroot.m
+++ b/src/geckomat/utilities/findGECKOroot.m
@@ -2,9 +2,9 @@ function [geckoPath, prevDir] = findGECKOroot()
 % findGECKOroot  Find the root of the GECKO directory.
 %
 % Finds the root of the GECKO directory, by searching for the path to
-% GECKO.png. Can also record the current directory, in case a function will
-% use the geckoPath to navigate to a precise folder, and it should return to
-% the previous directory afterwards.
+% GECKOInstaller.m. Can also record the current directory, in case a function
+% will use the geckoPath to navigate to a precise folder, and it should
+% return to the previous directory afterwards.
 %
 % Returns
 % -------

--- a/src/geckomat/utilities/getEnzymeBottlenecks.m
+++ b/src/geckomat/utilities/getEnzymeBottlenecks.m
@@ -28,13 +28,6 @@ function bottlenecks = getEnzymeBottlenecks(model, varargin)
 % --------
 %     bottlenecks = getEnzymeBottlenecks(ecModel);
 %     bottlenecks = getEnzymeBottlenecks(ecModel, 'top', 5);
-%
-% Notes
-% -----
-% Ported from geckopy's get_enzyme_bottlenecks (utilities/bottlenecks.py),
-% itself ported from the legacy geckopy package (Carrasco et al., 2023,
-% https://doi.org/10.1128/spectrum.01705-23), geckopy/flux_analysis.py:275-281
-% (get_protein_bottlenecks).
 
 p = parseGECKOargs(varargin, {'top', []});
 top = p.top;

--- a/src/geckomat/utilities/loadConventionalGEM.m
+++ b/src/geckomat/utilities/loadConventionalGEM.m
@@ -9,9 +9,10 @@ function model = loadConventionalGEM(varargin)
 % Name-Value Arguments
 % --------------------
 % filename : char
-%     name of the model file, located in the models/ subfolder of
-%     param.path as specified in the modelAdapter (default: the value
-%     specified as param.convGEM in the modelAdapter).
+%     name of the model file, without extension, located in the models/
+%     subfolder of param.path as specified in the modelAdapter; it is
+%     loaded as SBML (.xml) (default: the value specified as param.convGEM
+%     in the modelAdapter, which may instead point to a YAML file).
 % modelAdapter : ModelAdapter
 %     a loaded model adapter, from where the model folder is read (default:
 %     the current default model adapter).

--- a/src/geckomat/utilities/loadFluxData.m
+++ b/src/geckomat/utilities/loadFluxData.m
@@ -1,8 +1,8 @@
 function fluxData = loadFluxData(varargin)
 % loadFluxData  Load total protein measurements and exchange flux data.
 %
-% Loads total protein measurements and flux data (exchange fluxes for
-% carbon source, O2, CO2, etc.).
+% Loads total protein content and exchange flux data (e.g. carbon source,
+% O2, CO2) from a tab-delimited file.
 %
 % Name-Value Arguments
 % --------------------

--- a/src/geckomat/utilities/loadProtData.m
+++ b/src/geckomat/utilities/loadProtData.m
@@ -22,19 +22,26 @@ function protData = loadProtData(replPerCond, varargin)
 %     that was previously made by loadProtData.
 % filterData : logical
 %     whether abundances should be filtered. If false, minVal, maxRSD,
-%     maxMissing and addStdevs are not considered (default true).
+%     maxMissing, cutLowest and addStdevs are not considered (default true).
 % modelAdapter : ModelAdapter
 %     a loaded model adapter (default: the current default model adapter).
 % minVal : double
-%     threshold of mean protein measurement per condition (default 0).
+%     minimum mean protein measurement per condition; proteins with a lower
+%     mean abundance are discarded (set to NaN) for that condition (default
+%     0, i.e. no lower threshold).
 % maxRSD : double
-%     maximum relative standard per condition (default 1).
+%     maximum relative standard deviation (RSD, the standard deviation
+%     across replicates divided by their mean) allowed per condition;
+%     proteins exceeding it are discarded (set to NaN) for that condition
+%     (default 1, i.e. RSD up to 100%).
 % maxMissing : double
-%     ratio of replicates for which a protein level might be missing
-%     (default 1/3, or 1/2 if number of replicates = 2). If conditions have
-%     different number of replicates (as indicated in replPerCond),
-%     maxMissing can also be a vector of the same length as replPerCond,
-%     with individual maxMissing parameters for each replicate.
+%     minimum fraction of replicates within a condition that must have a
+%     measured value; proteins with fewer present replicates than this
+%     fraction requires are discarded (set to NaN) for that condition
+%     (default 2/3, i.e. at least two of three replicates must have a
+%     value). If conditions have different number of replicates (as
+%     indicated in replPerCond), maxMissing can also be a vector of the
+%     same length as replPerCond, with individual values per condition.
 % cutLowest : double
 %     percentage of lowest mean values per condition to be discarded (not
 %     considering NaN values) (default 5).

--- a/src/geckomat/utilities/pfbaEnzymes.m
+++ b/src/geckomat/utilities/pfbaEnzymes.m
@@ -39,22 +39,10 @@ function solution = pfbaEnzymes(model, varargin)
 %
 % Notes
 % -----
-% Ported from geckopy's pfba_enzymes (utilities/pfba_enzymes.py), itself
-% ported from the legacy geckopy package (Carrasco et al., 2023,
-% https://doi.org/10.1128/spectrum.01705-23), geckopy/flux_analysis.py:342-386
-% (pfba_protein).
-%
-% Fixes the objective as a constraint the same way solveLP's own minFlux=1
-% option does internally: a "fake metabolite" produced by each reaction
-% with the stoichiometry it has in the objective, constrained to at least
-% the target value (with the same 1e-6 relative safety margin solveLP
-% itself applies, to avoid spurious infeasibility from solver tolerance).
-%
-% usage_prot_<id> reactions are forward-only (lb=0) in the standard GECKO 3
-% layout. If any has lb<0 (reverse flux enabled), minimising its raw flux
-% would not minimise |flux| for that reaction, unlike geckopy's cobra-based
-% forward/reverse variable split --- this function errors in that case
-% rather than silently building an incorrect objective.
+% usage_prot_<id> reactions must be forward-only (lb=0), the standard
+% GECKO 3 layout; if any has a negative lower bound (reverse flux enabled),
+% pfbaEnzymes errors instead of building an objective that would fail to
+% minimise |flux| for that reaction.
 %
 % See also
 % --------

--- a/src/geckomat/utilities/reportEnzymeUsage.m
+++ b/src/geckomat/utilities/reportEnzymeUsage.m
@@ -1,7 +1,8 @@
 function usageReport = reportEnzymeUsage(ecModel, usageData, varargin)
 % reportEnzymeUsage  Summarize the results from enzymeUsage.
 %
-% Summarizes the results from enzymeUsage.
+% Ranks the enzymes from enzymeUsage into two tables: those with the
+% highest capacity usage, and those with the highest absolute usage.
 %
 % Parameters
 % ----------
@@ -13,17 +14,23 @@ function usageReport = reportEnzymeUsage(ecModel, usageData, varargin)
 % Name-Value Arguments
 % --------------------
 % highCapUsage : double
-%     minimum ratio of enzyme capacity usage to be considered as high usage
-%     (default 0.9, referring to a minimum of 90% capacity usage).
+%     minimum fraction of enzyme capacity usage to be listed as high usage
+%     (default 0.9, i.e. at least 90% capacity usage).
 % topAbsUsage : double
-%     number of top enzymes with highest absolute usage (default 10,
-%     returning the top 10 enzymes with highest absolute usage. With Inf or
-%     0, all enzymes are returned).
+%     how many top enzymes by absolute usage to list (default 10). Use 0
+%     or Inf to list all enzymes instead. Enzymes whose reactions carry no
+%     flux are never listed here, as they do not contribute to the
+%     solution.
 %
 % Returns
 % -------
-% usageReport : table
-%     table with summary information.
+% usageReport : struct
+%     highCapUsage : table
+%         enzymes at or above the highCapUsage threshold.
+%     topAbsUsage : table
+%         the topAbsUsage enzymes with the highest absolute usage.
+%     totalUsageFlux : double
+%         total protein pool used, i.e. the upper bound of prot_pool_exchange.
 %
 % Examples
 % --------

--- a/test/unit_tests/ecTestGEM/TestGEMAdapter.m
+++ b/test/unit_tests/ecTestGEM/TestGEMAdapter.m
@@ -38,10 +38,11 @@ classdef TestGEMAdapter < ModelAdapter
         end
 		
 		function [spont,spontRxnNames] = getSpontaneousReactions(obj,model)
-			% Matched by reaction id rather than a hardcoded position: this is
-			% called with the ecModel (already expanded into isozyme/reversibility
-			% variants) by getStandardKcat, not the plain 7-reaction conventional
-			% model, and R4's position among model.rxns is not the same in both.
+			% Flags which reactions in model are spontaneous (test reaction R4) and
+			% returns their names. Matches by reaction id rather than by position,
+			% so it still resolves correctly when model is an expanded ecModel (as
+			% passed by getStandardKcat) rather than the plain conventional model,
+			% where R4's position among model.rxns differs.
 			spont = strcmp(model.rxns, 'R4');
 			spontRxnNames = model.rxnNames(spont);
         end

--- a/test/unit_tests/geckoCoreFunctionTests.m
+++ b/test/unit_tests/geckoCoreFunctionTests.m
@@ -158,7 +158,11 @@ end
 
 %For both full and light
 function testgetECfromGEM_tc0006(testCase)
-    %full
+    % Verifies getECfromGEM copies EC codes from the conventional GEM's
+    % model.eccodes into ecModel.ec.eccodes, for both the full and light
+    % ecModel variants, either for every ec.rxns entry (ecRxns omitted) or
+    % only for a caller-supplied logical/index subset (ecRxns given), with
+    % all excluded entries left empty.
     geckoPath = findGECKOroot;
     adapter = ModelAdapterManager.getAdapter(fullfile(geckoPath,'test','unit_tests','ecTestGEM', 'TestGEMAdapter.m'));
     model = getGeckoTestModel();
@@ -184,7 +188,12 @@ end
 
 %For both full and light
 function testgetECfromDatabase_tc0007(testCase)
-    %full
+    % Verifies getECfromDatabase looks up EC codes from KEGG/UniProt data
+    % (via loadDatabases, in 'display' mode so results are not written back
+    % to model files) and stores them in ecModel.ec.eccodes, for both the
+    % full and light ecModel variants, either for every ec.rxns entry
+    % (ecRxns omitted) or only for a caller-supplied logical/index subset
+    % (ecRxns given), with all excluded entries left empty.
     geckoPath = findGECKOroot;
     adapter = ModelAdapterManager.getAdapter(fullfile(geckoPath,'test','unit_tests','ecTestGEM', 'TestGEMAdapter.m'));
     model = getGeckoTestModel();
@@ -219,7 +228,11 @@ function testModelAdapterManager_tc0008(testCase)
 end
 
 function testsaveECModel_tc0009(testCase)
-    % Test a round of model saving and loading
+    % Round-trips an ecModel through saveEcModel/loadEcModel and verifies the
+    % reloaded model matches the original, then verifies loadConventionalGEM
+    % reproduces the underlying conventional GEM, aside from the
+    % annotation/date/description/version fields it does not restore and the
+    % geneShortNames field it adds.
     geckoPath = findGECKOroot;
     adapter = ModelAdapterManager.getAdapter(fullfile(geckoPath,'test','unit_tests','ecTestGEM', 'TestGEMAdapter.m'));
     model = getGeckoTestModel();
@@ -237,7 +250,13 @@ function testsaveECModel_tc0009(testCase)
 end
 
 function testfuzzyKcatMatching_tc0010(testCase)
-    %full
+    % Verifies fuzzyKcatMatching against ecTestGEM's fixture BRENDA data, for
+    % both the full and light ecModel variants and for both the complete
+    % ec.rxns set (ecRxns omitted) and a caller-supplied subset (ecRxns
+    % given). Checks the returned kcats, substrates, eccodes, wildcardLvl and
+    % origin fields, confirming that a substrate match is preferred over an
+    % organism match and that a wildcarded EC match is used only as a last
+    % resort.
     geckoPath = findGECKOroot;
     adapter = ModelAdapterManager.getAdapter(fullfile(geckoPath,'test','unit_tests','ecTestGEM', 'TestGEMAdapter.m'));
     model = getGeckoTestModel();
@@ -598,12 +617,10 @@ end
 
 
 function testApplyKcatConstraintsDuplicateAccession_tc0017(testCase)
-    % Two ec.enzymes rows can map to the same prot_<accession> metabolite --
-    % distinct genes sharing one UniProt entry. applyKcatConstraints used to
-    % write model.S(linearIndices) = -newKcats(:,4) directly: a plain indexed
-    % assignment on a repeated linear index keeps only the last value written,
-    % silently dropping one enzyme's contribution instead of adding it to the
-    % other's.
+    % Verifies that when two ec.enzymes rows map to the same prot_<accession>
+    % metabolite (distinct genes sharing one UniProt entry), applyKcatConstraints
+    % sums both enzymes' protein-cost contributions into that metabolite's S
+    % matrix entry, instead of only keeping the last one written.
     clear model
     model.rxns = {'R1'};
     model.mets = {'prot_P1'};
@@ -680,20 +697,11 @@ end
 
 
 function testReportEnzymeUsageTopAbsUsageOutOfBounds_tc0019(testCase)
-    % reportEnzymeUsage's default topAbsUsage (10) used to reach
-    % usageData.protID(topUse(1:topAbsUsage)) unclamped: on any model with fewer
-    % than 10 enzymes -- ecTestGEM has 5 -- that indexed past the end of topUse
-    % and crashed. Regression test for the default call, plus the two other
-    % "all enzymes" spellings the docstring promises (0 and Inf), plus an
-    % ordinary in-range value left unaffected: all four must complete without
-    % erroring, which is what the indexing fix guarantees.
-    %
-    % All fluxes are zero on this fixture, so every enzyme is fully inactive;
-    % per raven-gecko-parity#18's reconciliation (tc0045), a fully-inactive
-    % enzyme is skipped rather than padded in, so all four calls now return
-    % zero rows regardless of the requested topAbsUsage -- that skip, not the
-    % row count, is what distinguishes an in-range request from the
-    % all-enzymes spellings on this particular (all-zero) fixture.
+    % Verifies reportEnzymeUsage's 'topAbsUsage' Name-Value argument does not
+    % error when the model has fewer enzymes than requested: the default (10)
+    % on ecTestGEM's 5-enzyme model, the two "report all enzymes" sentinel
+    % values (0 and Inf), and an ordinary in-range value (2) must all
+    % complete without indexing past the available rows.
     geckoPath = findGECKOroot;
     adapter = ModelAdapterManager.getAdapter(fullfile(geckoPath,'test','unit_tests','ecTestGEM', 'TestGEMAdapter.m'));
     model = getGeckoTestModel();
@@ -722,12 +730,11 @@ end
 
 
 function testSigmaFitterModelMatchesReturnedSigma_tc0020(testCase)
-    % sigmaFitter's own docstring promises the returned model has its protein
-    % pool "adapted to the optimal sigma-factor" -- but the grid-search loop
-    % left `model` sized for whichever sigma the loop tried *last* (i=100,
-    % i.e. sigma=1), not the best-fitting one `sigma` reports. Regression test:
-    % the returned model's protein-pool upper bound must equal Ptot*f*sigma*1000
-    % at the *returned* sigma, not at sigma=1 (unless they happen to coincide).
+    % Verifies that the model sigmaFitter returns has its protein-pool
+    % upper bound sized to the sigma value it also returns: the
+    % prot_pool_exchange upper bound must equal Ptot*f*sigma*1000 at that
+    % returned sigma, not at whichever sigma the internal grid search
+    % happened to try last.
     geckoPath = findGECKOroot;
     adapter = ModelAdapterManager.getAdapter(fullfile(geckoPath,'test','unit_tests','ecTestGEM', 'TestGEMAdapter.m'));
     model = getGeckoTestModel();
@@ -755,22 +762,13 @@ end
 
 
 function testFuzzyKcatMatchingWildcardIsPrefixNotSubstring_tc0021(testCase)
-    % fuzzyKcatMatching's wildcard escalation truncates an EC code to a prefix (e.g.
-    % '1.1.1.1' -> '1.-.-.-' -> truncated query '1.') and searches BRENDA's EC column
-    % for it via extract_string_matches. The optimized path (used whenever the
-    % ECIndexIds/EcIndexIndices index is available, i.e. always, from within
-    % fuzzyKcatMatching itself) used contains(...) instead of an anchored prefix
-    % match, so a query for enzyme class 1 ('1.') could also match an EC code from an
-    % unrelated class that merely happens to contain the same two characters
-    % somewhere else in its string -- '4.2.1.1' contains '1.' between its third and
-    % fourth levels.
-    %
-    % The fixture has one legitimate class-1 entry (a real wildcard match, giving the
-    % escalation loop something to succeed on and stop at) and one unrelated
-    % '4.2.1.1' entry with a deliberately *larger* kcat: mainMatch takes the max
-    % among same-level matches, so the bug (matching both) picks the larger, wrong
-    % value; the fix (matching only the real class-1 entry) picks the smaller, correct
-    % one.
+    % Verifies that fuzzyKcatMatching's wildcard escalation matches BRENDA EC
+    % codes by prefix, not by substring: escalating '1.1.1.1' to the
+    % broadest wildcard level searches for EC codes starting with '1.', so an
+    % unrelated code that merely contains '1.' elsewhere (e.g. '4.2.1.1')
+    % must not match. The fixture pairs one genuine class-1 BRENDA entry with
+    % one such unrelated, larger-kcat entry; the returned kcat must come from
+    % the genuine prefix match, not the larger unrelated value.
     geckoPath = findGECKOroot;
     adapter = ModelAdapterManager.getAdapter(fullfile(geckoPath,'test','unit_tests','ecTestGEM', 'TestGEMAdapter.m'));
     model = getGeckoTestModel();
@@ -818,31 +816,14 @@ end
 
 
 function testFuzzyKcatMatchingTieBreakRespectsWildcardCount_tc0022(testCase)
-    % iterativeMatch's cross-EC-token tie-break is supposed to (1) keep only the EC
-    % tokens that matched with the fewest wildcards, (2) among those keep the ones
-    % with the best (lowest) origin, then (3) take the largest kcat. Step 2's
-    % `best_pos = (origin == min(new_origin(new_origin~=0)))` re-evaluates
-    % `origin == ...` against the *full*, unfiltered origin vector instead of the
-    % wildcard-filtered subset from step 1 -- so any EC token that matched at a
-    % *worse* (higher) wildcard level, but happens to share the same origin value,
-    % is let back in. Step 3 then maximises kcat across that too-permissive set, so
-    % a less-specific, more-wildcarded match can silently win over a fully-specific
-    % one whenever it happens to report a bigger kcat.
-    %
-    % The fixture gives R2_EXP_1 two EC tokens: '9.9.9.1' matches BRENDA directly
-    % (0 wildcards, kcat 42); '9.9.8.-' only matches after escalating twice more (2
-    % wildcards, kcat 500) -- both land on origin 3 (organism matches, substrate
-    % deliberately does not, so origin 1/2 are skipped). The correct answer is the
-    % 0-wildcard match (42); the bug picks the 2-wildcard one (500) because both
-    % share origin 3.
-    %
-    % Found while running the kcat-gathering pipeline against real BRENDA data and
-    % yeast-GEM at genome scale in raven-gecko-parity: ~119 reactions got a kcat
-    % that genuinely differed (not just missing) between the MATLAB and Python
-    % implementations even after two other confirmed bugs were fixed; this
-    % tie-break scoping bug, triggered whenever a multi-EC-code reaction's tokens
-    % match at different wildcard levels but the same origin, accounts for at
-    % least some of those.
+    % Verifies fuzzyKcatMatching's cross-EC-token tie-break: when a
+    % reaction's multiple EC tokens match BRENDA at the same origin (organism
+    % tier) but different wildcard levels, the token matched with fewer
+    % wildcards must win, even if a more-wildcarded token happens to carry a
+    % larger kcat. The fixture gives one reaction two EC tokens that both
+    % resolve at the same origin -- one an exact (0-wildcard) match with a
+    % small kcat, the other a 2-wildcard match with a larger kcat -- and
+    % expects the exact match's kcat and wildcardLvl to be returned.
     geckoPath = findGECKOroot;
     adapter = ModelAdapterManager.getAdapter(fullfile(geckoPath,'test','unit_tests','ecTestGEM', 'TestGEMAdapter.m'));
     model = getGeckoTestModel();
@@ -891,24 +872,13 @@ end
 
 
 function testWriteOpenKineticsPredictorInputReactionSubsetIndex_tc0023(testCase)
-    % writeOpenKineticsPredictorInput restricts its work to the requested ecRxns
-    % subset by first building clearedS = reducedS(:, origRxnIdxs), then finding
-    % substrates with reactionIdxs = find(clearedS < 0) -- reactionIdxs is a
-    % *column position within that subset* (1..numel(ecRxnsIdx)), not an absolute
-    % index into model.ec.rxns. The next line indexed model.ec.rxnEnzMat directly
-    % with reactionIdxs, silently picking the wrong ec.rxns row (or the wrong
-    % protein set entirely) whenever the requested subset excludes any earlier
-    % ec.rxns entry -- which shifts every later entry's subset-position below its
-    % absolute position.
-    %
-    % ecTestGEM's R2 has two isozymes (G1+G2 complex, and G3 alone), each
-    % expanded to its own ec.rxns row (R2_EXP_1, R2_EXP_2) plus a reverse copy
-    % (R2_REV_EXP_1, R2_REV_EXP_2) -- ec.rxns order is [R2_EXP_1, R2_EXP_2,
-    % R2_REV_EXP_1, R2_REV_EXP_2, R3, R5]. Requesting ecRxns={R2_EXP_1, R2_EXP_2,
-    % R3} excludes the two REV entries in between, so R3's subset position (3)
-    % no longer equals its absolute ec.rxns position (5): the bug reads
-    % rxnEnzMat row 3 (R2_REV_EXP_1's genes, G1+G2) instead of row 5 (R3's own
-    % gene, G4), so R3/G4 never appears in the output and G1/G2 appear twice.
+    % Verifies writeOpenKineticsPredictorInput correctly maps a
+    % caller-supplied ecRxns subset back to the right ec.rxns rows even when
+    % that subset excludes entries that fall between the requested reactions
+    % in ec.rxns order: requesting a subset whose reactions are not
+    % contiguous in ec.rxns (excluding two entries in between) must still
+    % write the substrate/gene-sequence pairs belonging to the requested
+    % reactions, not those of the skipped-over entries.
     geckoPath = findGECKOroot;
     adapter = ModelAdapterManager.getAdapter(fullfile(geckoPath,'test','unit_tests','ecTestGEM', 'TestGEMAdapter.m'));
     model = getGeckoTestModel();
@@ -943,30 +913,14 @@ end
 
 
 function testGetEnzymeBottlenecksRanksByShadowPrice_tc0024(testCase)
-    % getEnzymeBottlenecks: solves the model, ranks enzymes by |shadow price| of
-    % their prot_<id> mass-balance constraint, returns the top N.
-    %
-    % An enzyme that carries zero flux at the optimum has a genuinely
-    % LP-dual-degenerate shadow price: confirmed across three independent
-    % environments (this repo's own local Windows run; geckopy's Python/gurobipy
-    % run; this exact test on GitHub Actions' Linux runner) that which value a
-    % zero-flux enzyme's row reports --- an exact 0, or the shared protein pool's
-    % own nonzero dual propagated uniformly to it --- depends on the solver
-    % build/platform/presolve path, not on the calling language, the fixture, or
-    % this function's own logic. All three environments solve the byte-identical
-    % LP; none of them are "wrong". R2 and R4 are still blocked below (leaving R3
-    % as the sole route m1c->m2c, the same fix enzyme_usage_ectestgem's own
-    % fixture needed for this exact model) so that at least the *primal* solution
-    % --- which enzymes carry flux, and how much --- is unique and stable; the
-    % *dual* (shadow price) for whichever enzymes end up at zero flux (P1/P2/P3
-    % here, since R2 is fully blocked) is not asserted to a specific value for
-    % that reason, on either side.
-    %
-    % What is asserted, and confirmed stable everywhere above: the objective
-    % value; every primal-derived column (flux, capUsage, upperBound); that the
-    % result is sorted by non-increasing |shadowPrice|; and that `top` limits
-    % the row count. Cross-verified against geckopy's get_enzyme_bottlenecks on
-    % the identical fixture for all of these.
+    % Verifies getEnzymeBottlenecks solves the model, ranks enzymes by the
+    % absolute shadow price of their prot_<id> mass-balance constraint, and
+    % returns the top N rows. Checks the primal-derived columns (flux,
+    % capUsage, upperBound) exactly, that rows are sorted by non-increasing
+    % |shadowPrice|, and that 'top' limits the row count -- but not the exact
+    % shadow-price value for an enzyme carrying zero flux at the optimum,
+    % since that value is LP-dual-degenerate and can vary with the solver's
+    % platform/presolve path.
     geckoPath = findGECKOroot;
     adapter = ModelAdapterManager.getAdapter(fullfile(geckoPath,'test','unit_tests','ecTestGEM', 'TestGEMAdapter.m'));
     model = getGeckoTestModel();
@@ -1004,16 +958,15 @@ end
 
 
 function testPfbaEnzymesMinimisesEnzymeUsage_tc0025(testCase)
-    % pfbaEnzymes: fixes the current objective (growth, via R5) as a constraint,
-    % then minimises total usage_prot_* flux. Cross-verified against geckopy's
-    % pfba_enzymes on the identical fixture (uniform kcat=10, protein pool
-    % Ptot=0.5/f=0.5/sigma=0.5): geckopy reports growth=90 exactly and
-    % enzyme_usage=125 exactly at the enzyme-minimising solution, using only
-    % usage_prot_P5 (every other usage reaction at 0). pfbaEnzymes.m reproduces
-    % the same solution up to the ~1e-6 relative safety margin it borrows from
-    % solveLP's own minFlux=1 "fake metabolite" technique (see solveLP.m) ---
-    % a deliberate, documented difference from geckopy's exact constraint, not
-    % a divergence in the algorithm itself.
+    % Verifies pfbaEnzymes fixes the current objective (growth, via R5) as a
+    % constraint and then minimises total usage_prot_* flux, reaching
+    % growth=90 and enzyme_usage=125 using only usage_prot_P5 (every other
+    % usage reaction at 0), within the ~1e-6 relative tolerance solveLP's own
+    % minFlux=1 constraint introduces. Also checks that 'fractionOfOptimum'
+    % scales both the fixed growth target and the resulting enzyme usage,
+    % that 'rxnId' can override which reaction is fixed as the objective, and
+    % that calling it on a gecko-light model (no usage_prot_* reactions to
+    % minimise over) raises an error.
     geckoPath = findGECKOroot;
     adapter = ModelAdapterManager.getAdapter(fullfile(geckoPath,'test','unit_tests','ecTestGEM', 'TestGEMAdapter.m'));
     model = getGeckoTestModel();
@@ -1059,13 +1012,13 @@ end
 
 
 function ecModel = fixtureForRelaxProteomicsGreedy()
-% Shared fixture: uniform kcat=10, protein pool sized via Ptot=0.5/f=0.5/
-% sigma=0.5 (unconstrained growth 90, matching testGetEnzymeBottlenecksRanksByShadowPrice_tc0024
-% and testPfbaEnzymesMinimisesEnzymeUsage_tc0025's own fixture). P5 is R5's
-% sole catalyst and the true bottleneck (confirmed by direct execution: R2/R3's
-% own enzymes never carry flux on this fixture); P4 catalyses R3, which is
-% never on the critical path, so constraining it never affects growth.
-% Constraining P5 to 10 and P4 to 5 drops growth to 7.2 = 90*(10/125).
+% Builds the shared fixture used by the relaxProteomicsGreedy tests below:
+% ecTestGEM with uniform kcat=10 and protein pool sized via
+% Ptot=0.5/f=0.5/sigma=0.5, giving unconstrained growth of 90. P5 is R5's
+% sole catalyst and the true bottleneck (R2/R3's own enzymes never carry
+% flux on this fixture); P4 catalyses R3, which is never on the critical
+% path. Concentrations are constrained to P5=10 and P4=5, which drops growth
+% to 7.2 = 90*(10/125).
 geckoPath = findGECKOroot;
 adapter = ModelAdapterManager.getAdapter(fullfile(geckoPath,'test','unit_tests','ecTestGEM', 'TestGEMAdapter.m'));
 model = getGeckoTestModel();
@@ -1084,13 +1037,12 @@ end
 
 
 function testRelaxProteomicsGreedyConverges_tc0026(testCase)
-    % relaxProteomicsGreedy: greedily relaxes the most-shadow-priced
+    % Verifies relaxProteomicsGreedy greedily relaxes the most-shadow-priced
     % proteomics-constrained enzyme each round until minimalGrowth is
-    % reached. Cross-verified against geckopy's relax_proteomics_greedy on
-    % the identical fixture: both sides converge in exactly one step,
-    % relaxing only P5 (the true bottleneck; P4's shadow price is 0, since
-    % R3 is never on the critical path here) straight to growth=90, with the
-    % same trace values (before=7.2, after=90, shadowPrice=-0.72).
+    % reached. On this fixture it converges in exactly one step, relaxing
+    % only P5 (the true bottleneck; P4's shadow price is 0 since R3 is never
+    % on the critical path) straight to growth=90, and records that step's
+    % trace (before=7.2, after=90, shadowPrice=-0.72).
     ecModel = fixtureForRelaxProteomicsGreedy();
 
     solBefore = solveLP(ecModel);
@@ -1111,11 +1063,11 @@ end
 
 
 function testRelaxProteomicsGreedyExhaustsCandidates_tc0027(testCase)
-    % An unreachable minimalGrowth relaxes every eligible enzyme (P5 then
-    % P4, in shadow-price order) and returns normally with converged=false
-    % once candidates run out --- distinct from the maxIterations case
-    % below, which raises instead. Cross-verified against geckopy: both
-    % relax {P5: 10, P4: 5} and report converged=False, finalGrowth=90.
+    % Verifies that when minimalGrowth is unreachable, relaxProteomicsGreedy
+    % relaxes every eligible enzyme (P5 then P4, in shadow-price order) and
+    % returns normally with converged=false, reporting finalGrowth=90, once
+    % candidates run out -- distinct from the maxIterations case below,
+    % which raises an error instead.
     ecModel = fixtureForRelaxProteomicsGreedy();
     result = relaxProteomicsGreedy(ecModel, 'minimalGrowth', 1000);
     verifyFalse(testCase, result.converged)
@@ -1125,10 +1077,10 @@ end
 
 
 function testRelaxProteomicsGreedyMaxIterationsRaises_tc0028(testCase)
-    % maxIterations=1 stops after relaxing only P5 (growth=90, still below
-    % the unreachable target) with one eligible candidate (P4) still
-    % remaining --- geckopy raises RuntimeError in exactly this situation;
-    % this errors too, rather than returning as if converged or exhausted.
+    % Verifies that maxIterations=1 stops relaxProteomicsGreedy after
+    % relaxing only P5 (growth=90, still below the unreachable target) while
+    % an eligible candidate (P4) remains: this raises an error rather than
+    % returning as if converged or exhausted.
     ecModel = fixtureForRelaxProteomicsGreedy();
     try
         relaxProteomicsGreedy(ecModel, 'minimalGrowth', 1000, 'maxIterations', 1);
@@ -1181,17 +1133,12 @@ end
 
 
 function testFetchOpenKineticsPredictorUseStoredMatchesReader_tc0030(testCase)
-    % fetchOpenKineticsPredictor's useStored path is the one code path that
-    % needs no live API call (parse an already-downloaded result file), so
-    % it's the one directly testable here. It now delegates to
-    % readOpenKineticsPredictorOutput instead of its own separate parsing
-    % subfunction (the pre-port version of this file duplicated ~90 lines of
-    % that parsing logic, which had drifted: it never added the 'OKP-'
-    % prefix readOpenKineticsPredictorOutput.m puts on kcatSource, and it
-    % computed kcatList.source as "the most frequent provenance" instead of
-    % the constant 'OpenKineticsPredictor' every other kcat-gathering
-    % function uses). Confirms the two entry points now produce identical
-    % kcatList structs from the same result file.
+    % Verifies fetchOpenKineticsPredictor's 'useStored' path (parsing an
+    % already-downloaded result file, the only path testable without a live
+    % API call) delegates to readOpenKineticsPredictorOutput and produces an
+    % identical kcatList struct: the 'OKP-' prefix on kcatSource, and the
+    % constant source 'OpenKineticsPredictor' used by every kcat-gathering
+    % function.
     geckoPath = findGECKOroot;
     adapter = ModelAdapterManager.getAdapter(fullfile(geckoPath,'test','unit_tests','ecTestGEM', 'TestGEMAdapter.m'));
     model = getGeckoTestModel();
@@ -1223,14 +1170,11 @@ end
 
 
 function testGetECfromGEMRejectsMalformedComponents_tc0031(testCase)
-    % getECfromGEM's validity regex used \w (any word character) instead of
-    % \d+ for each of the four EC components, so malformed strings containing
-    % letters or underscores -- e.g. '1.1.1.n12' (a real BRENDA "undefined
-    % subclass"-style code) or '1_2_3_4' -- passed validation and were kept
-    % instead of being rejected. geckopy's fill_eccodes_from_gem already
-    % requires each component to be purely digits or the wildcard '-'; this
-    % brings MATLAB's validation in line, and closes an already-documented
-    % divergence (raven-gecko-parity's ledgers/gecko.yml, getECfromGEM row).
+    % Verifies getECfromGEM only accepts an EC code whose four
+    % dot-separated components are each purely digits or the wildcard '-':
+    % a malformed component containing letters or underscores (e.g.
+    % '1.1.1.n12' or '1_2_3_4') is rejected and left empty, while a
+    % well-formed wildcarded code (e.g. '1.2.3.-') is kept.
     clear model
     model.rxns = {'R1';'R2';'R3';'R4'};
     model.eccodes = {'1.1.1.1'; '1.1.1.n12'; '1_2_3_4'; '1.2.3.-'};
@@ -1244,18 +1188,13 @@ end
 
 
 function testFindECInDBIntersectionDedupesWildcardPair_tc0032(testCase)
-    % findECInDB's private intersection() helper does not dedupe its output:
-    % when prev_EC contains both a specific EC code and its own wildcard
-    % parent (e.g. '1.1.1.1' and '1.1.1.-'), both independently pair-match
-    % the same entry in new_EC, and the inner loop appends the resolved code
-    % twice -- e.g. producing '1.1.1.1;1.1.1.1' instead of '1.1.1.1'.
-    %
-    % Gene 1 maps to a single protein annotated with two EC tokens,
+    % Verifies that reconciling EC annotations across an AND-complex's genes
+    % via findECInDB de-duplicates a code that matches via both itself and
+    % its own wildcard parent. Gene 1's protein carries two EC tokens,
     % '1.1.1.1' and its own wildcard parent '1.1.1.-' (space-separated, the
     % format getECstring expects for one protein's multiple activities);
-    % gene 2 maps to a single protein annotated with just '1.1.1.1'.
-    % Reconciling across the two genes (an AND-complex) via intersection
-    % must return the code once, not twice.
+    % gene 2's protein carries just '1.1.1.1'. The intersection across both
+    % genes must return '1.1.1.1' once, not twice.
     geneHashMap = containers.Map({'G1','G2'}, {1,2});
     geneIndex = {1; 2};
     DBecNum = {'1.1.1.1 1.1.1.-'; '1.1.1.1'};
@@ -1267,12 +1206,10 @@ end
 
 
 function testFuzzyKcatMatchingWildcardExhaustionDoesNotCrash_tc0033(testCase)
-    % iterativeMatch's wildcard-escalation loop had no termination guard: once
-    % an EC token is escalated to fully wildcarded ('-.-.-.-') and still finds
-    % no BRENDA match, the next escalation attempt computed
-    % dot_pos(4-wild_num) with wild_num==4 -- dot_pos(0), an invalid index --
-    % and errored instead of reporting "no match". Reachable for any EC class
-    % with zero BRENDA coverage even at the broadest wildcard level.
+    % Verifies that when an EC code has no BRENDA match at any wildcard
+    % level, including the fully wildcarded '-.-.-.-', fuzzyKcatMatching's
+    % escalation loop terminates cleanly and reports "no match" (kcat 0,
+    % origin NaN) instead of erroring.
     geckoPath = findGECKOroot;
     adapter = ModelAdapterManager.getAdapter(fullfile(geckoPath,'test','unit_tests','ecTestGEM', 'TestGEMAdapter.m'));
     model = getGeckoTestModel();
@@ -1320,19 +1257,13 @@ end
 
 
 function testGetStandardKcatUsesSubsystemKcatWheneverAnyMatches_tc0034(testCase)
-    % kcatSubSystemIdx is a one-hot vector produced by comparing a reaction's
-    % first subSystem against every subSystem that has a computed kcat;
-    % all(kcatSubSystemIdx) only ever succeeds for a model with exactly one
-    % subSystem in total. With more than one subSystem, that branch never
-    % fires and every reaction silently falls back to the model-wide
-    % standardKcat, masking the subsystem-specific kcat this code path
-    % exists to apply.
-    %
-    % R1 has no GPR and shares subSystem 'SubA' with R3 (kcat 50); R5 sits in
-    % a different subSystem 'SubB' (kcat 999, deliberately large so it would
-    % skew the model-wide median standardKcat fallback if picked by
-    % mistake). With two distinct subSystems in play, R1 must be assigned
-    % SubA's kcat (50), not the fallback.
+    % Verifies that getStandardKcat assigns a GPR-less reaction its own
+    % subsystem's kcat whenever any subsystem has a computed kcat, even when
+    % the model has more than one distinct subsystem. R1 has no GPR and
+    % shares subSystem 'SubA' with R3 (kcat 50); R5 sits in a different
+    % subSystem 'SubB' (kcat 999, deliberately large so it would skew the
+    % model-wide fallback if picked by mistake). R1 must be assigned SubA's
+    % kcat (50), not the model-wide standardKcat fallback.
     geckoPath = findGECKOroot;
     adapter = ModelAdapterManager.getAdapter(fullfile(geckoPath,'test','unit_tests','ecTestGEM', 'TestGEMAdapter.m'));
     model = getGeckoTestModel();
@@ -1356,11 +1287,11 @@ end
 
 
 function testReadDLKcatOutputSubstrateMatchIsCaseInsensitive_tc0035(testCase)
-    % readDLKcatOutput's substrate-name check against model.metNames used ismember's
-    % default case-sensitive comparison, so a DLKcat output file whose substrate names
-    % differ only in case from model.metNames -- e.g. an SBML loader that normalises
-    % capitalisation differently than whatever produced the DLKcat input -- was reported
-    % as "substrate not found" even though the same metabolite is genuinely present.
+    % Verifies readDLKcatOutput matches a DLKcat output file's substrate
+    % names against model.metNames case-insensitively, so an output file
+    % whose substrate names differ only in case from model.metNames (e.g.
+    % 'M1' vs. 'm1') is still recognized rather than reported as
+    % "substrate not found".
     geckoPath = findGECKOroot;
     adapter = ModelAdapterManager.getAdapter(fullfile(geckoPath,'test','unit_tests','ecTestGEM', 'TestGEMAdapter.m'));
     model = getGeckoTestModel();
@@ -1384,12 +1315,12 @@ end
 
 
 function testMakeEcModelSortsEcGenes_tc0036(testCase)
-    % makeEcModel's ec.genes (and ec.enzymes/ec.mw/ec.sequence, permuted in lockstep) used
-    % to keep model.genes' own array order -- whatever order genes happened to be declared
-    % in, not necessarily alphabetical or reproducible across independently-built models of
-    % the same organism. ecTestGEM's genes (G1..G5) already happen to be declared
-    % alphabetically, so the existing makeEcModel tests don't exercise this: reorder them
-    % here so a passing test actually proves the sort, not an already-sorted pass-through.
+    % Verifies makeEcModel sorts ec.genes alphabetically (permuting
+    % ec.enzymes/ec.mw/ec.sequence in lockstep), regardless of the order
+    % genes are declared in model.genes. Reorders ecTestGEM's genes (which
+    % are otherwise already alphabetical) before building the ecModel, so
+    % the test actually exercises the sort rather than an already-sorted
+    % pass-through.
     geckoPath = findGECKOroot;
     adapter = ModelAdapterManager.getAdapter(fullfile(geckoPath,'test','unit_tests','ecTestGEM', 'TestGEMAdapter.m'));
     model = getGeckoTestModel();
@@ -1411,10 +1342,9 @@ end
 
 
 function testReadDLKcatOutputUnrecognizedSubstrateErrorsCleanly_tc0037(testCase)
-    % dispEM (a RAVEN utility) was removed from RAVEN in RAVEN#659 and replaced with
-    % native warning/error + ravenList; readDLKcatOutput.m still called the now-nonexistent
-    % dispEM, so reporting a genuinely unrecognized substrate crashed with "Undefined
-    % function 'dispEM'" instead of the intended, informative error.
+    % Verifies that readDLKcatOutput reports a genuinely unrecognized
+    % substrate with a clean error naming the substrate, rather than
+    % crashing.
     geckoPath = findGECKOroot;
     adapter = ModelAdapterManager.getAdapter(fullfile(geckoPath,'test','unit_tests','ecTestGEM', 'TestGEMAdapter.m'));
     model = getGeckoTestModel();
@@ -1445,8 +1375,8 @@ end
 
 
 function testLoadDatabasesDuplicateUniprotEntriesErrorsCleanly_tc0038(testCase)
-    % Same dispEM removal as tc0037, a different caller: loadDatabases.m's duplicate-entry
-    % check crashed with "Undefined function 'dispEM'" instead of reporting the duplicates.
+    % Verifies that loadDatabases reports duplicate UniProt entries with a
+    % clean error, rather than crashing.
     geckoPath = findGECKOroot;
     adapter = ModelAdapterManager.getAdapter(fullfile(geckoPath,'test','unit_tests','ecTestGEM', 'TestGEMAdapter.m'));
 
@@ -1477,9 +1407,9 @@ end
 
 
 function testAddNewRxnsToECMissingGeneErrorsCleanly_tc0039(testCase)
-    % Same dispEM removal as tc0037, a different caller: addNewRxnsToEC.m's
-    % missing-gene check crashed with "Undefined function 'dispEM'" instead of naming
-    % the gene that needed to be passed as newEnzymes input.
+    % Verifies that addNewRxnsToEC reports a gene referenced in grRules but
+    % missing from newEnzymes with a clean error naming that gene, rather
+    % than crashing.
     geckoPath = findGECKOroot;
     adapter = ModelAdapterManager.getAdapter(fullfile(geckoPath,'test','unit_tests','ecTestGEM', 'TestGEMAdapter.m'));
     model = getGeckoTestModel();
@@ -1510,9 +1440,9 @@ end
 
 
 function testGetSubsetEcModelMismatchedReactionsErrorsCleanly_tc0040(testCase)
-    % Same dispEM removal as tc0037, a different caller: getSubsetEcModel.m's
-    % same-starting-GEM check crashed with "Undefined function 'dispEM'" instead of
-    % naming the reactions that could not be matched.
+    % Verifies that getSubsetEcModel reports reactions in smallGEM that
+    % cannot be matched to bigEcModel with a clean error naming those
+    % reactions, rather than crashing.
     clear bigEcModel smallGEM
     bigEcModel.rxns = {'R1';'R2_EXP_1'};
     smallGEM.rxns   = {'R1';'R3'};
@@ -1585,12 +1515,10 @@ end
 
 
 function testMergeDLKcatAndFuzzyKcatsDelegatesToMergeKcats_tc0042(testCase)
-    % mergeDLKcatAndFuzzyKcats is now a thin wrapper around mergeKcats;
-    % confirms its own three-tier priority order (database_top > dlkcat >
-    % database_bottom) still resolves exactly as before the split, using the
-    % same style of fixture testKcats_tc0011 already established for this
-    % function (kept as a positional call, since that is still this
-    % function's own documented calling convention).
+    % Verifies mergeDLKcatAndFuzzyKcats, called positionally, delegates to
+    % mergeKcats using a fixed three-tier priority order (database_top >
+    % dlkcat > database_bottom), using the same style of fixture
+    % testKcats_tc0011 already established for this function.
     fuzzyList.rxns        = {'R1'; 'R2'; 'R3'};
     fuzzyList.kcats       = [5; 8; 2];
     fuzzyList.genes       = {{}; {}; {}};
@@ -1623,13 +1551,11 @@ end
 
 
 function testLoadBRENDAdataParsesNewTsvFormat_tc0043(testCase)
-    % loadBRENDAdata migrated from the old headerless max_KCAT.txt/max_MW.txt/max_SA.txt
-    % (EC-prefixed, //-suffixed organism) to kcat.tsv/mw.tsv/sa.tsv, the format produced by
-    % the geckopy brenda-refresh CLI: a `#`-prefixed release line, a tab-delimited column
-    % header, bare EC codes, plain organism strings, and (for kcat/sa) both a _max and
-    % _median aggregate per row. Confirms the new shape parses correctly and that the max
-    % column -- not median -- is the one used, matching this function's previous,
-    % single-aggregate behaviour.
+    % Verifies loadBRENDAdata parses kcat.tsv/mw.tsv/sa.tsv files (a
+    % `#`-prefixed release line, a tab-delimited column header, bare EC
+    % codes, plain organism strings, and, for kcat/sa, both a _max and
+    % _median aggregate per row), and that the _max column -- not _median --
+    % is the value used.
     geckoPath = findGECKOroot;
     adapter = ModelAdapterManager.getAdapter(fullfile(geckoPath,'test','unit_tests','ecTestGEM', 'TestGEMAdapter.m'));
 
@@ -1672,13 +1598,12 @@ end
 
 
 function testMakeEcModelFallsBackToKeggForUnmatchedGenes_tc0044(testCase)
-    % makeEcModel's stage 7 used to leave a UniProt-unmatched gene with no enzyme
-    % data at all (MW, sequence, accession all missing -- the gene is dropped from
-    % ec.genes entirely and only shows up in the noUniprot warning). It now
-    % consults databases.kegg for any such gene: ec.enzymes gets the UniProt
-    % accession carried on the KEGG row, or -- when that column is itself empty,
-    % as tested here -- the bare KEGG gene id as a fallback identifier, with
-    % ec.mw/ec.sequence still coming from the KEGG row either way.
+    % Verifies that makeEcModel falls back to databases.kegg for a gene with
+    % no UniProt match: ec.mw and ec.sequence are filled from the KEGG row,
+    % and ec.enzymes gets the UniProt accession carried on that row, or --
+    % when that column is itself empty, as tested here -- the bare KEGG gene
+    % id as a fallback identifier. Such a gene must not appear in the
+    % noUniprot output.
     geckoPath = findGECKOroot;
     adapter = ModelAdapterManager.getAdapter(fullfile(geckoPath,'test','unit_tests','ecTestGEM', 'TestGEMAdapter.m'));
     model = getGeckoTestModel();
@@ -1717,20 +1642,11 @@ end
 
 
 function testReportEnzymeUsageSkipsOnlyFullyInactiveEnzymes_tc0045(testCase)
-    % reportEnzymeUsage's topAbsUsage table used to pad in a placeholder row
-    % for an enzyme with NO flux-carrying reactions at all -- isscalar(find(
-    % carriedFlux)) is false both for zero matches and for multiple matches,
-    % so a fully-inactive enzyme took the same "combined usage" branch as a
-    % genuinely multi-reaction one. Reconciled with geckopy's
-    % report_enzyme_usage (raven-gecko-parity#18): an enzyme is only skipped
-    % when *every* one of its reactions carries no flux; if some do and some
-    % don't, it is still reported, attributed to the flux-carrying subset --
-    % unaffected by this fix, asserted here too so a future change can't
-    % quietly break it.
-    %
-    % Minimal hand-built ecModel-like struct with three enzymes exercising
-    % all three cases directly, without going through the full
-    % makeEcModel/getECfromGEM pipeline:
+    % Verifies reportEnzymeUsage's topAbsUsage table skips an enzyme only
+    % when every one of its reactions carries no flux; an enzyme with some
+    % flux-carrying and some inactive reactions is still reported, attributed
+    % only to the flux-carrying subset. Uses a minimal hand-built
+    % ecModel-like struct with three enzymes covering all three cases:
     %   P1 -- Ra, Rb, neither carries flux            -> skipped entirely
     %   P2 -- Rc, Rd; only Rc carries flux             -> single-branch, Rc only
     %   P3 -- Re, Rf, Rg; Re and Rf carry flux, Rg not -> combined-branch, Re+Rf only
@@ -1801,14 +1717,11 @@ end
 
 
 function testCalculateMWReconciledWithGeckopy_tc0046(testCase)
-    % calculateMW used to disagree with geckopy's calculate_mw on the water
-    % mass, X and B's residue masses, case-sensitivity, and the
-    % no-recognized-residue return value; reconciled to match geckopy on
-    % all four (raven-gecko-parity#11): water 18.01528 (was 18); X and B
-    % computed as the mean of their possible standard residues (was
-    % pre-rounded constants 126.50/114.60); case-insensitive (was
-    % case-sensitive, silently ignoring lowercase); NaN, not 18, when no
-    % residue is recognized.
+    % Verifies calculateMW's residue-mass handling: the water constant is
+    % 18.01528; ambiguous residues X and B are computed as the mean of their
+    % possible standard residues rather than a fixed constant; residue
+    % letters are matched case-insensitively; and a sequence with no
+    % recognized residue returns NaN rather than just the water mass.
     verifyTrue(testCase, isnan(calculateMW('')))
     verifyTrue(testCase, isnan(calculateMW('123 ---')))
     % X: mean of the 20 standard residues (118.885) + water.

--- a/tutorials/full_ecModel/YeastGEMAdapter.m
+++ b/tutorials/full_ecModel/YeastGEMAdapter.m
@@ -87,11 +87,15 @@ classdef YeastGEMAdapter < ModelAdapter
    end
 
         function ecModel = makeModelAnaerobic(obj,ecModel)
-            % Taken from yeast-GEM 9.0.2
+            % Constrains ecModel to anaerobic growth conditions (blocked
+            % oxygen uptake, enabled sterol/fatty acid exchanges, and other
+            % curations), as implemented in anaerobicModel_GECKO.
             ecModel = anaerobicModel_GECKO(ecModel);
         end
 	    function ecModel = changeProteinBiomass(obj,ecModel,Ptot)
-            % Skip this step for now
+            % Currently a no-op: returns ecModel unchanged. Intended to
+            % rescale the biomass reaction's protein content to Ptot (as
+            % scaleBioMass_GECKO would), but this step is disabled for now.
             ecModel = ecModel;
             % Taken from yeast-GEM 9.0.2
             %ecModel = scaleBioMass_GECKO(ecModel,'protein',Ptot,'carbohydrate',false);

--- a/tutorials/full_ecModel/code/anaerobicModel_GECKO.m
+++ b/tutorials/full_ecModel/code/anaerobicModel_GECKO.m
@@ -6,8 +6,6 @@ function model = anaerobicModel(model)
 %   intracellular reactions are enabled/disabled to yield a model that is
 %   able to reach similar exchange rates as measured.
 %
-%   This function was updated as part of release v9.1.0.
-%
 % Input:
 %   model           yeast-GEM model structure, which is aerobic by default
 %

--- a/tutorials/full_ecModel/code/changeMedia.m
+++ b/tutorials/full_ecModel/code/changeMedia.m
@@ -5,19 +5,29 @@ function [model,pos] = changeMedia(model,c_source,media,anox,flux)
 % simulations on different carbon sources.
 %
 % INPUT:
-%   - model:  An enzyme constrained model
-%   - media:  Media type ('YEP' for complex, 
+%   - model:     An enzyme constrained model
+%   - c_source:  Name of the carbon source exchange reaction (e.g.
+%                'D-glucose'); the ' exchange' suffix is appended internally
+%   - media:  Media type ('YEP' for complex,
 %                         'MAA' minimal with Aminoacids,
 %                         'MIN' for minimal media,
 %                         'MIN+His' for minimal media with his
 %                         'MIN+Arg' for minimal media with arg
 %                         'MIN+Citrate' for minimal media with Citrate)
-%   - anox:   (optional) TRUE if anaerobic conditions are desired, DEFAULT=
-%             FALSE
-%   - flux:   (Optional) A cell array with measured uptake fluxes in mmol/gDwh
+%   - anox:   (optional) the string 'anaerobic' to additionally constrain
+%             the model to anaerobic conditions (via anaerobicModel_GECKO);
+%             any other value keeps the model aerobic. DEFAULT= FALSE
+%             (aerobic)
+%   - flux:   (Optional) A numeric vector with measured uptake fluxes (in
+%             mmol/gDWh), one value per exchange reaction in the same
+%             order as c_source followed by the amino acids/nucleotides
+%             fixed for the chosen media
 %
 % OUTPUT:
 %   - model: The ECmodel with the specified medium constraints
+%   - pos:   Indices (into model.rxns) of the carbon source and amino
+%            acid/nucleotide exchange reactions used to define the medium,
+%            in the same fixed order across all media types
 %
 % Ivan Domenzain        2020-01-17
 % Feiran Li             2020-11-10

--- a/tutorials/full_ecModel/code/plotlightVSfull.m
+++ b/tutorials/full_ecModel/code/plotlightVSfull.m
@@ -10,6 +10,12 @@ function [solL, solF] = plotlightVSfull()
 % 3. The flux distributions are mapped back to the conventional GEM to
 % allow for comparison.
 % 4. A plot is made and stored in ../output/lightVSfull.pdf.
+%
+% Output:
+%   solL    flux distribution of the light ecModel at maximum growth rate,
+%           mapped onto the conventional (non-ec) GEM reactions
+%   solF    flux distribution of the full ecModel at maximum growth rate,
+%           mapped onto the conventional (non-ec) GEM reactions
 
 %
 adapterLocation = fullfile(findGECKOroot,'tutorials','full_ecModel','YeastGEMAdapter.m');

--- a/tutorials/full_ecModel/code/scaleBioMass_GECKO.m
+++ b/tutorials/full_ecModel/code/scaleBioMass_GECKO.m
@@ -12,8 +12,9 @@ function model = scaleBioMass_GECKO(model,component,new_value,balance_out,dispOu
 %   balance_out     (string, optional) biomass component that will be used
 %                   to balance out the biomass composition, so that the
 %                   total mass adds up to 1 g/gDCW. This is highly
-%                   recommended (default = empty, no scaling takes place)
-%   dispOutput      (bool, optional) displayed outoupt (default = true)
+%                   recommended (default = empty, no balancing takes place)
+%   dispOutput      (bool, optional) whether to print the resulting biomass
+%                   composition to the command window (default = true)
 %
 % Output:
 %   model          (struct) modified yeast-GEM model

--- a/tutorials/full_ecModel/protocol.m
+++ b/tutorials/full_ecModel/protocol.m
@@ -14,13 +14,11 @@
 % CURATION, BETTER SENSITIVITY TUNING AND KCATS PREDICTED BY CATAPRO.
 % HTTPS://GITHUB.COM/SYSBIOCHALMERS/YEAST-GEM
 %
-% In comparison to the published GECKO3 Nature Protocols paper, this script
-% might have more up-to-date descriptions about the capabilities and
-% functions, which were introduced after the Nature Protocols paper was
-% published. This script will have additional commands and analyses that
-% are not included in the paper as such. This script should always work
-% with the most recent GECKO3 release. The STAGE and STEP numbers match
-% those in the Nature Protocols paper.
+% This script is kept up to date with the most recent GECKO3 release, and
+% may include more detailed descriptions, additional commands, and
+% analyses beyond what is shown in the published GECKO3 Nature Protocols
+% paper. The STAGE and STEP numbers match those in the Nature Protocols
+% paper.
 
 %% Installation
 % - Install RAVEN & GECKO

--- a/tutorials/light_ecModel/code/HT29_ftINIT.m
+++ b/tutorials/light_ecModel/code/HT29_ftINIT.m
@@ -1,7 +1,7 @@
 % For reference, code is provided here that was used to make a cell-line
 % specific (HT-29) model of human-GEM with the ftINIT function of RAVEN.
 % This model, stored at tutorials/light_ecModel/models/HT-29-GEM.yml, is
-% for demontration purposes only. The intention of the code in this file is
+% for demonstration purposes only. The intention of the code in this file is
 % not to routinely regenerate this model file, but merely as reference how
 % the HT-29-GEM was constructed.
 

--- a/tutorials/light_ecModel/protocol.m
+++ b/tutorials/light_ecModel/protocol.m
@@ -1,9 +1,9 @@
 % This file accompanies the GECKO 3 Nature Protocols paper https://doi.org/10.1038/s41596-023-00931-7.
 %
 % The function of this script is to demonstrate the reconstruction and
-% analysis of a *full* ecModel. As example, it here uses the yeast-GEM
-% model of Saccharomyces cerevisiae as starting point. However, this script
-% does not claim to construct a "production-ready" ecYeastGEM model:
+% analysis of a *light* ecModel. As example, it here uses the Human-GEM
+% model of Homo sapiens as starting point. However, this script
+% does not claim to construct a "production-ready" ecHumanGEM model:
 % dependent on how you intend to use the ecModel it may require additional
 % curation and evaluation.
 %


### PR DESCRIPTION
Full pass over every header docstring in `src/geckomat`, `test/`, and
`tutorials/`, following up on #459/#460/#461. Goal: a docstring should tell
a reader what the function produces and what its inputs do, without
narrating implementation history or repeating itself. Comment/docstring
only -- no functional changes, verified by a full 46/46 unit test pass.

Recurring patterns fixed across many files:
- A one-line summary immediately followed by a paragraph that just restates
  it (`findMetSmiles`, `findECInDB`, `runDLKcat`, `loadFluxData`,
  `getConcControlCoeffs`, `abc_max`, `findMaxValue`, `sensitivityTuning`,
  `sigmaFitter`, `truncateValues`, and others).
- `Returns`/argument descriptions that no longer matched the code: wrong
  struct field names in `kcatList` (`fuzzyKcatMatching`, `readDLKcatOutput`,
  `selectKcatValue`), a vague "table"/"struct" return with no indication of
  its actual columns/fields (`applyComplexData`, `applyCustomKcats`,
  `mergeKcats`, `mergeDLKcatAndFuzzyKcats`, `updateProtPool`), an inaccurate
  threshold (`applyCustomKcats`: code uses `>= 50%`, not `> 50%`), and a
  docstring that predated the KEGG-fallback path added later in the same
  function (`makeEcModel`).
- Historical/regression narration replaced with a plain statement of
  current behavior: `loadBRENDAdata`'s "previous, single-aggregate
  behaviour" note, `relaxProteomicsGreedy`'s porting/attribution paragraph,
  `updateProtPool`'s "Obsolete since / Before GECKO 3.2.0" framing (now
  states when the function errors instead), `pfbaEnzymes`'s
  geckopy-attribution and implementation-detail asides, and 32 of the
  46 tests in `geckoCoreFunctionTests.m` whose docstrings were empty
  (`%full`) or long bug-regression narratives (RAVEN/PR/issue references,
  "used to...", "cross-verified against geckopy" framing) -- rewritten to
  state the scenario each test verifies.
- Tutorial/adapter scripts: `changeMedia` was missing two documented
  parameters and mis-described two others (`anox` isn't boolean, `flux`
  isn't a cell array); `scaleBioMass_GECKO` mis-described its own default
  behavior; `light_ecModel/protocol.m`'s header wrongly described the
  *full* yeast-GEM model instead of the light Human-GEM one it actually
  covers.

Functions found with no docstring at all (mostly small local helpers, plus
`ModelAdapter`/`ModelAdapterManager`'s methods and `GECKOInstaller`'s
static methods) were left untouched rather than given an invented one --
out of scope for a wording/accuracy pass.