### PR TITLE
fix: isozyme kcat selection and EC-annotation overwrite bugs

### DIFF
--- a/src/geckomat/change_model/applyKcatConstraints.m
+++ b/src/geckomat/change_model/applyKcatConstraints.m
@@ -136,10 +136,19 @@ else %GECKO light formulation, where prot_pool represents all usages
         % of MW/kcat values.
         MWkcat = (model.ec.rxnEnzMat(ecIdx,:) * model.ec.mw) ./ model.ec.kcat(ecIdx);
         % If kcat was zero, MWkcat is Inf. If no enzyme info was found,
-        % MWkcat is NaN. Correct both back to zero
-        MWkcat(isinf(MWkcat) | isnan(MWkcat)) = 0;
-        % Select the lowest MW/kcat (= most efficient), and convert to /hour
-        model.S(prot_pool_idx, hasEc(i)) = -min(MWkcat/3600);
+        % MWkcat is NaN. Drop those isozymes *before* selecting the
+        % cheapest one: correcting them to zero and including them in the
+        % min() below would let an isozyme with no kcat assigned always
+        % win over a real kcat on another isozyme of the same reaction.
+        validKcat = ~isinf(MWkcat) & ~isnan(MWkcat);
+        if any(validKcat)
+            % Select the lowest MW/kcat (= most efficient), and convert to /hour
+            model.S(prot_pool_idx, hasEc(i)) = -min(MWkcat(validKcat)/3600);
+        else
+            % No isozyme of this reaction has a usable kcat; leave it
+            % unconstrained by enzyme usage.
+            model.S(prot_pool_idx, hasEc(i)) = 0;
+        end
     end
 end
 end

--- a/src/geckomat/get_enzyme_data/copyECtoGEM.m
+++ b/src/geckomat/get_enzyme_data/copyECtoGEM.m
@@ -13,8 +13,10 @@ function ecModel = copyECtoGEM(ecModel, varargin)
 % --------------------
 % overwrite : logical
 %     whether existing (non-empty) ecModel.eccodes entries should be
-%     overwritten. Empty ecModel.eccodes entries are always overwritten if
-%     possible (default false).
+%     overwritten by a non-empty ecModel.ec.eccodes entry. Empty
+%     ecModel.eccodes entries are always overwritten if possible (default
+%     false). An empty ecModel.ec.eccodes source entry is never copied, so
+%     it can never erase an existing annotation.
 %
 % Returns
 % -------
@@ -41,6 +43,12 @@ if ~isfield(ecModel,'eccodes')
 end
 
 if overwrite
+    % Never overwrite an existing eccodes entry with an empty source: an
+    % unset ec.eccodes value means "no info to copy", not "clear the
+    % annotation".
+    nonEmptySource = false(size(a));
+    nonEmptySource(a) = ~cellfun(@isempty, ecModel.ec.eccodes(b(a)));
+    a = a & nonEmptySource;
     ecModel.eccodes(a) = ecModel.ec.eccodes(b(a));
 else % Only replace emptyEcCodes
     emptyEcCodes = cellfun(@isempty, ecModel.eccodes);

--- a/test/unit_tests/geckoCoreFunctionTests.m
+++ b/test/unit_tests/geckoCoreFunctionTests.m
@@ -1822,3 +1822,88 @@ function testCalculateMWReconciledWithGeckopy_tc0046(testCase)
     verifyEqual(testCase, calculateMW('ACDEFGHIKLMNPQRSTVWY'), 2395.71528, 'AbsTol', 1e-9)
 end
 
+function testApplyKcatConstraintsLightSkipsUnassignedIsozyme_tc0047(testCase)
+    % raven-gecko-parity#57: in the light formulation, when one isozyme of
+    % a reaction has no kcat assigned (kcat==0, i.e. an Inf MW/kcat) and
+    % another isozyme does, applyKcatConstraints used to correct the
+    % unassigned isozyme's Inf cost to 0 *before* taking min() across
+    % isozymes, so that fabricated zero always won -- silently leaving
+    % the reaction unconstrained by enzyme usage even though a real kcat
+    % was available on another isozyme. Fixed to drop isozymes with no
+    % usable kcat before selecting the cheapest one, matching geckopy's
+    % apply_kcat_constraints.
+    geckoPath = findGECKOroot;
+    adapter = ModelAdapterManager.getAdapter(fullfile(geckoPath,'test','unit_tests','ecTestGEM', 'TestGEMAdapter.m'));
+    model = getGeckoTestModel();
+    lecModel = makeEcModel(model, true, adapter);
+    lecModel = getECfromGEM(lecModel);
+    lecModel = applyComplexData(lecModel, [], adapter, false);
+
+    % R2's two isozymes: 001_R2 (complex G1+G2), 002_R2 (single G3, MW 30000).
+    complexIdx = find(strcmp(lecModel.ec.rxns,'001_R2'));
+    singleIdx  = find(strcmp(lecModel.ec.rxns,'002_R2'));
+    lecModel.ec.kcat(complexIdx) = 0; % unassigned
+    lecModel.ec.kcat(singleIdx)  = 7; % real kcat
+
+    lecModel = applyKcatConstraints(lecModel);
+
+    % Only the single-gene isozyme has a usable kcat, so its cost must be
+    % the one written -- not the fabricated zero from the unassigned
+    % complex.
+    expected = -30000/7/3600;
+    verifyEqual(testCase,full(lecModel.S(strcmp(lecModel.mets, 'prot_pool'),strcmp(lecModel.rxns, 'R2'))),expected,"AbsTol",10^-10)
+end
+
+function testApplyKcatConstraintsLightNoValidIsozymeUncosted_tc0048(testCase)
+    % Companion to tc0047: when *every* isozyme of a reaction lacks a
+    % usable kcat, the reaction is left unconstrained (S coefficient 0),
+    % same as before the raven-gecko-parity#57 fix.
+    geckoPath = findGECKOroot;
+    adapter = ModelAdapterManager.getAdapter(fullfile(geckoPath,'test','unit_tests','ecTestGEM', 'TestGEMAdapter.m'));
+    model = getGeckoTestModel();
+    lecModel = makeEcModel(model, true, adapter);
+    lecModel = getECfromGEM(lecModel);
+    lecModel = applyComplexData(lecModel, [], adapter, false);
+
+    lecModel = applyKcatConstraints(lecModel); % default kcat==0 everywhere
+
+    verifyEqual(testCase,full(lecModel.S(strcmp(lecModel.mets, 'prot_pool'),strcmp(lecModel.rxns, 'R2'))),0,"AbsTol",10^-10)
+end
+
+function testCopyECtoGEMOverwriteNeverErasesWithEmptySource_tc0049(testCase)
+    % raven-gecko-parity#79: overwrite=true used to copy ec.eccodes
+    % verbatim, including empty entries -- so a reaction with a real,
+    % populated eccodes annotation could be silently erased just because
+    % the ec-structure's entry for the same reaction happened to be
+    % empty. Fixed so an empty ec.eccodes source is never copied,
+    % matching geckopy's copy_ec_to_gem.
+    ecModel = struct();
+    ecModel.rxns = {'R1';'R2';'R3'};
+    ecModel.eccodes = {'1.1.1.1';'';'2.2.2.2'}; % R1, R3 already populated
+    ecModel.ec = struct();
+    ecModel.ec.rxns = {'R1';'R2';'R3'};
+    ecModel.ec.eccodes = {'';'3.3.3.3';''}; % R1, R3 have no new info; R2 does
+
+    result = copyECtoGEM(ecModel, 'overwrite', true);
+    % R1's and R3's real annotations must survive an empty ec.eccodes source.
+    verifyEqual(testCase,result.eccodes{1},'1.1.1.1')
+    verifyEqual(testCase,result.eccodes{3},'2.2.2.2')
+    % R2 had nothing before and gets the new, non-empty value.
+    verifyEqual(testCase,result.eccodes{2},'3.3.3.3')
+end
+
+function testCopyECtoGEMOverwriteFalseStillFillsEmptyEntries_tc0050(testCase)
+    % Sanity check that the overwrite=false path (unchanged by
+    % raven-gecko-parity#79) still fills only empty entries.
+    ecModel = struct();
+    ecModel.rxns = {'R1';'R2'};
+    ecModel.eccodes = {'1.1.1.1';''};
+    ecModel.ec = struct();
+    ecModel.ec.rxns = {'R1';'R2'};
+    ecModel.ec.eccodes = {'9.9.9.9';'3.3.3.3'};
+
+    result = copyECtoGEM(ecModel); % overwrite defaults to false
+    verifyEqual(testCase,result.eccodes{1},'1.1.1.1') % untouched
+    verifyEqual(testCase,result.eccodes{2},'3.3.3.3') % filled in
+end
+


### PR DESCRIPTION
## Summary

Two independent correctness fixes, both confirmed against geckopy's already-correct behavior and decided in raven-gecko-parity#57 / raven-gecko-parity#79:

**`applyKcatConstraints` (light formulation)** — when a reaction had both a kcat-assigned isozyme and an unassigned one, the unassigned isozyme's `Inf` cost (kcat==0) was corrected to `0` *before* `min()` was taken across isozymes, so that fabricated zero always won over any real kcat — silently leaving the reaction under-constrained by enzyme usage, with no warning. Isozymes with no usable kcat (or unresolved MW) are now excluded before the comparison instead, matching geckopy's `apply_kcat_constraints`. A reaction with no valid isozyme at all is still left uncosted, same as before.

**`copyECtoGEM`** — `overwrite=true` copied `ec.eccodes` verbatim, including empty entries, so a real, populated `ecModel.eccodes` annotation could be silently erased just because the corresponding `ec`-structure entry happened to be empty. An empty source entry is now never copied, whether or not `overwrite` is set — matching geckopy's `copy_ec_to_gem`, which already documents this exact MATLAB behavior as a divergence it deliberately didn't replicate.

Both fixes and their four new regression tests (`geckoCoreFunctionTests.m` tc0047–tc0050) were reviewed with @eduardk before implementation — see raven-gecko-parity#57 and raven-gecko-parity#79 for the discussion.

Fixes raven-gecko-parity#57
Fixes raven-gecko-parity#79

## Test plan
- [x] `geckoCoreFunctionTests`: 50 passed, 0 failed (full suite, RAVEN develop3 on path, glpk solver)
- [x] New tests specifically exercise: a mixed valid/invalid-isozyme reaction picks the real kcat; an all-invalid reaction stays uncosted; `overwrite=true` no longer erases a populated annotation with an empty source; `overwrite=false` still only fills empty entries