### PR TITLE
fix: makeEcModel's protein usage reactions match the model's subSystems convention

### DIFF
--- a/src/geckomat/change_model/makeEcModel.m
+++ b/src/geckomat/change_model/makeEcModel.m
@@ -436,6 +436,18 @@ pool.metNotes     = 'Enzyme-usage protein pool';
 model = addMets(model,pool);
 
 %11: Add protein usage reactions.
+% Match the model's own subSystems convention (a cell array of chars, or a
+% cell array of cell arrays of chars -- RAVEN's checkModelStruct requires
+% the whole field to be consistently one or the other) rather than always
+% assuming one shape: mixing the two here is what left new ecModels unable
+% to be saved once RAVEN's own reconciliation in addRxns stopped papering
+% over the mismatch.
+if isfield(model,'subSystems') && ~isempty(model.subSystems) && ...
+        ~any(cellfun(@iscell,model.subSystems))
+    protUsageSubSystem = {'Protein usage'};
+else
+    protUsageSubSystem = {{'Protein usage'}};
+end
 if ~geckoLight
     rxnNum                    = numel(proteinMets.mets);
     usageRxns.rxns            = strcat('usage_',proteinMets.mets);
@@ -451,7 +463,7 @@ if ~geckoLight
     usageRxns.rev             = ones(rxnNum,1);
     usageRxns.grRules         = ec.genes(uniprotSortId);
     if isfield(model,'subSystems')
-        usageRxns.subSystems  = repmat({'Protein usage'}, rxnNum, 1);
+        usageRxns.subSystems  = repmat(protUsageSubSystem, rxnNum, 1);
     end
     model = addRxns(model,usageRxns);
 end
@@ -465,7 +477,7 @@ poolRxn.lb              = 0;
 poolRxn.ub              = 1000;
 poolRxn.rev             = 1;
 if isfield(model,'subSystems')
-    poolRxn.subSystems  = 'Protein usage';
+    poolRxn.subSystems  = protUsageSubSystem;
 end
 model = addRxns(model,poolRxn);
 

--- a/test/unit_tests/geckoCoreFunctionTests.m
+++ b/test/unit_tests/geckoCoreFunctionTests.m
@@ -1820,3 +1820,39 @@ function testCopyECtoGEMOverwriteFalseStillFillsEmptyEntries_tc0050(testCase)
     verifyEqual(testCase,result.eccodes{2},'3.3.3.3') % filled in
 end
 
+function testMakeEcModelSubSystemsMatchModelConvention_tc0051(testCase)
+    % GECKO#412: usage_prot_* and prot_pool_exchange always assigned a
+    % bare-char subSystems entry ('Protein usage'), regardless of whether
+    % the rest of the model used that convention or the nested
+    % cell-array-of-cell-arrays one (the common case for a real GEM).
+    % Reported against a RAVEN release whose addRxns did not reconcile a
+    % resulting bare-char/nested mix, so checkModelStruct rejected it at
+    % save time ("the subSystems field must be a cell array"). Current
+    % RAVEN's addRxns reconciles that mismatch on its own, so this test
+    % cannot reproduce the save-time crash directly; it instead pins down
+    % that makeEcModel itself now always emits a value matching the
+    % model's own convention, rather than relying on addRxns to paper
+    % over a mismatch.
+    geckoPath = findGECKOroot;
+    adapter = ModelAdapterManager.getAdapter(fullfile(geckoPath,'test','unit_tests','ecTestGEM', 'TestGEMAdapter.m'));
+    model = getGeckoTestModel();
+    model.subSystems = repmat({{''}}, size(model.rxns));
+    model.subSystems(strcmp(model.rxns,'R2')) = {{'Metabolism'}};
+
+    ecModel = makeEcModel(model, false, adapter);
+
+    isNested  = cellfun(@iscell, ecModel.subSystems);
+    isCellStr = cellfun(@ischar, ecModel.subSystems);
+    verifyTrue(testCase, all(isNested) || all(isCellStr), ...
+        'ecModel.subSystems mixes bare chars with nested cells')
+
+    usageIdx = find(startsWith(ecModel.rxns,'usage_prot_'));
+    verifyGreaterThan(testCase, numel(usageIdx), 0)
+    for i = 1:numel(usageIdx)
+        verifyEqual(testCase, ecModel.subSystems{usageIdx(i)}, {'Protein usage'})
+    end
+
+    poolIdx = find(strcmp(ecModel.rxns,'prot_pool_exchange'));
+    verifyEqual(testCase, ecModel.subSystems{poolIdx}, {'Protein usage'})
+end
+


### PR DESCRIPTION
Closes #412.

`usage_prot_*` and `prot_pool_exchange` always got a bare-char `subSystems`
entry (`'Protein usage'`), regardless of whether the rest of the model used
that convention or RAVEN's other supported one -- a cell array of cell
arrays (the shape a real GEM typically uses, since a reaction can carry
more than one subsystem). Mixing the two within one model's `subSystems`
field is exactly what RAVEN's `checkModelStruct` rejects ("the subSystems
field must be a cell array..."), and since `makeEcModel` builds the model
successfully either way, this only surfaced later, at save time
(`saveEcModel` -> `writeYAMLmodel` -> `checkModelStruct`) -- matching what
was reported.

`makeEcModel` now checks the model's own `subSystems` convention once
(nested if the field is absent/empty, matching either type otherwise) and
assigns a matching value for both reaction types instead of always using
a bare char.

**On the test**: current RAVEN's `addRxns` already reconciles a
bare-char/nested mismatch on its own when merging reactions into a model,
so against the RAVEN version in this repo's test setup, the original
save-time crash this issue reports can't be reproduced directly -- it
depends on a RAVEN release whose `addRxns` didn't yet do that
reconciliation. The added test (`tc0051`) instead pins down that
`makeEcModel` itself now always emits a value matching the model's own
convention, rather than relying on `addRxns` to paper over a mismatch;
full suite (51/51) passes.