### PR TITLE
fix: ecFVA reads each canonical reaction's bound from its own group's solve

### DIFF
--- a/src/geckomat/utilities/ecFVA.m
+++ b/src/geckomat/utilities/ecFVA.m
@@ -1,4 +1,4 @@
-function [minFlux, maxFlux] = ecFVA(ecModel, model)
+function [minFlux, maxFlux] = ecFVA(ecModel, model, varargin)
 % ecFVA  Run flux variability analysis on an ecModel.
 %
 % Flux variability analysis is performed on the ecModel, and isozymic
@@ -15,6 +15,14 @@ function [minFlux, maxFlux] = ecFVA(ecModel, model)
 %     non-ecModel variant of the ecModel, to which the minFlux and maxFlux
 %     will be mapped.
 %
+% Name-Value Arguments
+% --------------------
+% runParallel : logical
+%     speed up calculations by parallel processing. Requires the MATLAB
+%     Parallel Computing Toolbox. If this is not installed, the
+%     calculations will not be parallelized, regardless of what is
+%     indicated as runParallel (default true).
+%
 % Returns
 % -------
 % minFlux : double
@@ -30,6 +38,10 @@ function [minFlux, maxFlux] = ecFVA(ecModel, model)
 % --------
 % mapRxnsToConv, plotEcFVA
 
+p = parseGECKOargs(varargin, { ...
+    'runParallel', true});
+runParallel = p.runParallel;
+
 rxnIDs = regexprep(ecModel.rxns,'(_REV)?(_EXP_\d+)?','');
 [rxnIDmap, convRxnID] = findgroups(rxnIDs);
 
@@ -37,14 +49,15 @@ N = numel(convRxnID);
 maxFluxByGroup = nan(N,1);
 minFluxByGroup = nan(N,1);
 
-pool = gcp('nocreate');
-if isempty(pool)
-    parpool;
-end
+% nW == 0 forces parfor to run as a plain for loop (no pool required or
+% created); nW == Inf lets Parallel Computing Toolbox manage the pool.
+% Falls back to serial automatically when the toolbox isn't installed,
+% rather than erroring the way an unconditional gcp/parpool call would.
+nW = parallelWorkersRAVEN(runParallel);
 
 PB = progressReport(N, 'Running ecFVA');
 
-parfor i=1:N
+parfor (i=1:N, nW)
     tmpModel = ecModel;
     tmpModel.c = zeros(numel(tmpModel.rxns),1);
 

--- a/src/geckomat/utilities/ecFVA.m
+++ b/src/geckomat/utilities/ecFVA.m
@@ -33,15 +33,15 @@ function [minFlux, maxFlux] = ecFVA(ecModel, model)
 rxnIDs = regexprep(ecModel.rxns,'(_REV)?(_EXP_\d+)?','');
 [rxnIDmap, convRxnID] = findgroups(rxnIDs);
 
-solMaxAll = nan(numel(ecModel.rxns),numel(convRxnID));
-solMinAll = solMaxAll;
+N = numel(convRxnID);
+maxFluxByGroup = nan(N,1);
+minFluxByGroup = nan(N,1);
 
 pool = gcp('nocreate');
 if isempty(pool)
     parpool;
 end
 
-N = numel(convRxnID);
 PB = progressReport(N, 'Running ecFVA');
 
 parfor i=1:N
@@ -58,32 +58,34 @@ parfor i=1:N
     tmpModel.c(rxnsToMin) = -1;
     solMax=solveLP(tmpModel);
     if ~isempty(solMax.x)
-        solMaxAll(:,i)=solMax.x;
+        % Exact bound for this canonical reaction, read directly off this
+        % group's own solve (the "diagonal"): forward minus reverse
+        % variants from the one LP that jointly optimised them, not the
+        % best value each variant happened to reach in whichever group's
+        % solve maximised it -- an "envelope" that can combine values from
+        % different, not necessarily jointly feasible, flux distributions.
+        maxFluxByGroup(i) = sum(solMax.x(rxnsToMax)) - sum(solMax.x(rxnsToMin));
     end
     tmpModel.c(rxnsToMax) = -1;
     tmpModel.c(rxnsToMin) = 1;
     solMin=solveLP(tmpModel);
     if ~isempty(solMin.x)
-        solMinAll(:,i)=solMin.x;
-    end    
+        minFluxByGroup(i) = sum(solMin.x(rxnsToMax)) - sum(solMin.x(rxnsToMin));
+    end
     count(PB);
 end
 PB.done;
 
-minFlux=min(solMinAll,[],2,'omitnan');
-maxFlux=max(solMaxAll,[],2,'omitnan');
-
-mappedFlux = mapRxnsToConv(ecModel,model,[minFlux maxFlux]);
-
-minFlux=mappedFlux(:,1);
-maxFlux=mappedFlux(:,2);
-
-% Mapped flux might have swapped directionality: min/max might be swapped
-swapDir = minFlux > maxFlux;
-if any(swapDir)
-    tmpFlux = minFlux(swapDir);
-    minFlux(swapDir) = maxFlux(swapDir);
-    maxFlux(swapDir) = tmpFlux;
+% Reorder from canonical-id order to model.rxns order. No min/max swap
+% correction is needed here (unlike a row-reduced envelope): both bounds
+% come from the same group's LP over the same feasible region with only
+% the objective direction flipped, so minFluxByGroup(i) <= maxFluxByGroup(i)
+% always holds whenever both solves succeeded.
+[mapCheck, origIdx] = ismember(model.rxns, convRxnID);
+if ~all(mapCheck)
+    error('Not all reactions from model.rxns can be found in the ecModel. Are you sure that ecModel is derived from model?')
 end
+minFlux = minFluxByGroup(origIdx);
+maxFlux = maxFluxByGroup(origIdx);
 
 end

--- a/test/unit_tests/geckoCoreFunctionTests.m
+++ b/test/unit_tests/geckoCoreFunctionTests.m
@@ -1898,7 +1898,24 @@ function testEcFVAIsozymeSplitReactionUsesExactDiagonalBound_tc0052(testCase)
     ecModel = setProtPoolSize(ecModel, [], [], [], adapter);
     ecModel.ub(strcmp(ecModel.rxns,'prot_pool_exchange')) = 1e6;
 
-    [~, maxFlux] = ecFVA(ecModel, model);
+    % ecFVA unconditionally calls parpool/gcp, which errors outright
+    % (rather than just running serially) where Parallel Computing
+    % Toolbox isn't available -- a pre-existing property of ecFVA.m, not
+    % something this fix introduces or could work around here. Caught
+    % here, rather than pre-checked with license(), because a pre-check
+    % proved unreliable in practice (observed passing standalone and in
+    % this same suite's own environment probe, yet still reporting
+    % unavailable when this test itself ran) -- reacting to the actual
+    % failure is the one check that cannot give a false negative.
+    try
+        [~, maxFlux] = ecFVA(ecModel, model);
+    catch ME
+        if strcmp(ME.identifier,'MATLAB:UndefinedFunction') && ...
+                (contains(ME.message,'gcp') || contains(ME.message,'parpool'))
+            testCase.assumeFail('Parallel Computing Toolbox not available; ecFVA requires it.')
+        end
+        rethrow(ME)
+    end
     r2 = strcmp(model.rxns, 'R2');
     verifyEqual(testCase, maxFlux(r2), 12, 'AbsTol', 1e-6)
 end

--- a/test/unit_tests/geckoCoreFunctionTests.m
+++ b/test/unit_tests/geckoCoreFunctionTests.m
@@ -1856,3 +1856,50 @@ function testMakeEcModelSubSystemsMatchModelConvention_tc0051(testCase)
     verifyEqual(testCase, ecModel.subSystems{poolIdx}, {'Protein usage'})
 end
 
+function testEcFVAIsozymeSplitReactionUsesExactDiagonalBound_tc0052(testCase)
+    % raven-gecko-parity#72: for a canonical reaction split across isozyme
+    % variants that compete for a shared limiting resource, ecFVA used to
+    % read each variant's row-wise max/min across *every* canonical
+    % group's solve before summing forward and subtracting reverse
+    % variants -- an "envelope" that can combine values from different,
+    % not-necessarily-jointly-feasible flux distributions. Confirmed
+    % empirically here, not just argued from code: R2's two isozymes
+    % (G1+G2 complex, G3 single) share one upstream supply (R1, capped at
+    % 12, the only route to R2 since R3/R4 are blocked); each isozyme can
+    % reach 12 alone, but never jointly past 12. The unfixed ecFVA reports
+    % maxFlux(R2) = 24 -- double what any feasible flux distribution can
+    % attain -- because some *other* canonical group's solve happens to
+    % report R2_EXP_1 near its own max as a non-objective side effect, and
+    % a different group's solve does the same for R2_EXP_2, and the
+    % row-wise reduction sums the two independently. The fixed version
+    % reads each canonical reaction's bound only from its own group's
+    % solve (the "diagonal"), matching geckopy's ec_fva.
+    geckoPath = findGECKOroot;
+    adapter = ModelAdapterManager.getAdapter(fullfile(geckoPath,'test','unit_tests','ecTestGEM', 'TestGEMAdapter.m'));
+    model = getGeckoTestModel();
+
+    % Force all m1->m2 flux through R2's two isozymes.
+    model.lb(strcmp(model.rxns,'R3')) = 0; model.ub(strcmp(model.rxns,'R3')) = 0;
+    model.lb(strcmp(model.rxns,'R4')) = 0; model.ub(strcmp(model.rxns,'R4')) = 0;
+    % Shared upstream supply, tightly capped: the two isozymes must
+    % compete for it.
+    model.lb(strcmp(model.rxns,'R1')) = 0; model.ub(strcmp(model.rxns,'R1')) = 12;
+    % Forward-only: R2's reverse direction would let a futile
+    % R2_EXP_1/R2_REV_EXP_1 cycle inflate R2_EXP_1's own flux with no net
+    % mass-balance effect, unrelated to what this test is exercising.
+    model.lb(strcmp(model.rxns,'R2')) = 0;
+
+    ecModel = makeEcModel(model, false, adapter);
+    ecModel = getECfromGEM(ecModel);
+    % Generous kcat everywhere: the shared R1 supply must be the binding
+    % constraint, not enzyme cost.
+    ecModel.ec.kcat(:) = 1000;
+    ecModel = applyKcatConstraints(ecModel);
+    ecModel = setProtPoolSize(ecModel, [], [], [], adapter);
+    ecModel.ub(strcmp(ecModel.rxns,'prot_pool_exchange')) = 1e6;
+
+    [~, maxFlux] = ecFVA(ecModel, model);
+    r2 = strcmp(model.rxns, 'R2');
+    verifyEqual(testCase, maxFlux(r2), 12, 'AbsTol', 1e-6)
+end
+

--- a/test/unit_tests/geckoCoreFunctionTests.m
+++ b/test/unit_tests/geckoCoreFunctionTests.m
@@ -1898,24 +1898,11 @@ function testEcFVAIsozymeSplitReactionUsesExactDiagonalBound_tc0052(testCase)
     ecModel = setProtPoolSize(ecModel, [], [], [], adapter);
     ecModel.ub(strcmp(ecModel.rxns,'prot_pool_exchange')) = 1e6;
 
-    % ecFVA unconditionally calls parpool/gcp, which errors outright
-    % (rather than just running serially) where Parallel Computing
-    % Toolbox isn't available -- a pre-existing property of ecFVA.m, not
-    % something this fix introduces or could work around here. Caught
-    % here, rather than pre-checked with license(), because a pre-check
-    % proved unreliable in practice (observed passing standalone and in
-    % this same suite's own environment probe, yet still reporting
-    % unavailable when this test itself ran) -- reacting to the actual
-    % failure is the one check that cannot give a false negative.
-    try
-        [~, maxFlux] = ecFVA(ecModel, model);
-    catch ME
-        if strcmp(ME.identifier,'MATLAB:UndefinedFunction') && ...
-                (contains(ME.message,'gcp') || contains(ME.message,'parpool'))
-            testCase.assumeFail('Parallel Computing Toolbox not available; ecFVA requires it.')
-        end
-        rethrow(ME)
-    end
+    % runParallel=false: exercises the plain-for-loop path directly and
+    % keeps this test independent of whether Parallel Computing Toolbox
+    % happens to be installed wherever it runs (raven-gecko-parity#72's
+    % follow-up: ecFVA no longer requires it at all).
+    [~, maxFlux] = ecFVA(ecModel, model, 'runParallel', false);
     r2 = strcmp(model.rxns, 'R2');
     verifyEqual(testCase, maxFlux(r2), 12, 'AbsTol', 1e-6)
 end


### PR DESCRIPTION
## Summary
Fixes [raven-gecko-parity#72](https://github.com/SysBioChalmers/raven-gecko-parity/issues/72).

`ecFVA` grouped ec-reactions into canonical ids and solved one LP per group (forward variants at objective `+1`, reverse at `-1`), but then reduced **every** ec-reaction's flux row-wise across **all** N group solves (`min(solMinAll,[],2,'omitnan')` / `max(...)`) before summing forward and subtracting reverse variants per canonical id. That row-wise step mixes values harvested from different, non-objective vertices of *unrelated* groups' solves — an "envelope" that, for a canonical reaction split across isozyme variants competing for a shared limiting resource, can report a combined flux no single feasible distribution actually attains.

Confirmed empirically, not just argued from reading the code: built a fixture where two isozymes share one upstream supply capped at 12 (`R1`, the only route to `R2` with `R3`/`R4` blocked) — each isozyme alone can reach 12, but never jointly past 12. The unfixed `ecFVA` reported `maxFlux(R2) = 24`.

Now reads each canonical reaction's bound only from its own group's solve (the "diagonal"), matching geckopy's `ec_fva`, which already does this and documents the same distinction (`_postprocess`'s docstring: *"the true per-reaction FVA range, not the outer envelope..."*). The `solMaxAll`/`solMinAll` big matrices and the `mapRxnsToConv` call are gone — each group now accumulates its own forward-minus-reverse value directly. The post-hoc min/max swap correction is also no longer needed: both bounds now come from the same group's LP over the same feasible region with only the objective direction flipped, so `min <= max` holds by construction.

**Also fixes ecFVA's hard Parallel Computing Toolbox dependency**, spotted while adding the regression test: `ecFVA` unconditionally called `gcp`/`parpool`, which *errors outright* rather than falling back to serial execution where the toolbox isn't installed — GECKO's own CI runner has no such license, so this was breaking the very first unit test to ever call `ecFVA` directly. RAVEN's own `randomSampling` never calls `gcp`/`parpool` directly at all; it resolves a `parfor` worker count via `parallelWorkersRAVEN` (`0` forces a plain `for` loop, `Inf` lets the toolbox manage the pool) behind a `runParallel` name-value argument. `ecFVA` now does the same — new optional `runParallel` argument (default `true`), no functional change when the toolbox is available and left at its default.

## Test plan
- [x] New regression test `testEcFVAIsozymeSplitReactionUsesExactDiagonalBound_tc0052`, calling `runParallel=false` so it deterministically exercises the fix regardless of Parallel Computing Toolbox availability, empirically confirming `maxFlux(R2) = 12` (not 24) on the resource-constrained isozyme fixture
- [x] Full suite: 52 passed, 0 failed