### PR TITLE
selectKcatValue: fix crashing criteria='median'/'mean'

### DIFF
--- a/src/geckomat/gather_kcats/selectKcatValue.m
+++ b/src/geckomat/gather_kcats/selectKcatValue.m
@@ -26,7 +26,11 @@ function [model, rxnIdx] = selectKcatValue(model,kcatList,varargin)
 % --------------------
 % criteria : char
 %     which kcat value should be selected if multiple values are provided.
-%     Options: 'max', 'min', 'median', 'mean' (default 'max').
+%     Options: 'max', 'min', 'median', 'mean' (default 'max'). The written
+%     model.ec.source is taken from the matching entry for 'max'/'min'; for
+%     'median'/'mean', where the selected value need not equal any single
+%     input, it is taken from the first entry instead (arbitrary but
+%     deterministic, since an aggregate has no single "winning" source).
 % overwrite : char
 %     whether existing kcat values should be overwritten. Options: 'true',
 %     'false', 'ifHigher'. The last option will overwrite only if the new
@@ -97,9 +101,11 @@ for i=1:numel(idxInModelUnique)
         case 'min'
             [selectedKcats(i),j] = min(kcatList.kcats(idxMatch));
         case 'median'
-            [selectedKcats(i),j] = median(kcatList.kcats(idxMatch));
+            selectedKcats(i) = median(kcatList.kcats(idxMatch));
+            j = 1;
         case 'mean'
-            [selectedKcats(i),j] = mean(kcatList.kcats(idxMatch));
+            selectedKcats(i) = mean(kcatList.kcats(idxMatch));
+            j = 1;
         otherwise
             error('Invalid criteria specified')
     end

--- a/test/unit_tests/geckoCoreFunctionTests.m
+++ b/test/unit_tests/geckoCoreFunctionTests.m
@@ -1907,3 +1907,32 @@ function testEcFVAIsozymeSplitReactionUsesExactDiagonalBound_tc0052(testCase)
     verifyEqual(testCase, maxFlux(r2), 12, 'AbsTol', 1e-6)
 end
 
+function testSelectKcatValueMedianAndMeanCompute_tc0053(testCase)
+    % raven-gecko-parity#73: criteria='median'/'mean' used to request a
+    % second output from median()/mean(), which -- unlike max()/min() --
+    % are single-output-only builtins; every call crashed with "Too many
+    % output arguments" the moment the loop reached a reaction using
+    % either criteria, including the function's own docstring example.
+    % Fixed to compute the aggregate directly and attribute model.ec.source
+    % to the first matching kcatList row, matching geckopy's
+    % apply_kcat_list (there is no single "winning" row for an aggregate
+    % value, so this is an arbitrary but deterministic convention shared
+    % by both implementations).
+    model.ec.rxns   = {'r1'};
+    model.ec.kcat   = 0;
+    model.ec.source = {''};
+
+    kcatList.rxns       = {'r1'; 'r1'; 'r1'};
+    kcatList.kcats      = [1; 3; 5];
+    kcatList.kcatSource = {'src_first'; 'src_middle'; 'src_last'};
+    medianModel = selectKcatValue(model, kcatList, 'criteria', 'median');
+    verifyEqual(testCase, medianModel.ec.kcat, 3)
+    verifyEqual(testCase, medianModel.ec.source, {'src_first'})
+
+    kcatList.kcats      = [2; 4; 6];
+    kcatList.kcatSource = {'a'; 'b'; 'c'};
+    meanModel = selectKcatValue(model, kcatList, 'criteria', 'mean');
+    verifyEqual(testCase, meanModel.ec.kcat, 4)
+    verifyEqual(testCase, meanModel.ec.source, {'a'})
+end
+


### PR DESCRIPTION
## Summary
- `selectKcatValue.m`'s `criteria='median'`/`'mean'` cases requested a second output from `median()`/`mean()`, which -- unlike `max()`/`min()` -- are single-output-only builtins. Every call crashed with `"Too many output arguments"` the moment the loop reached a reaction using either criteria, including the function's own docstring usage example (line 47).
- Fixed to compute the aggregate directly, and attribute the written `model.ec.source` to the first matching `kcatList` row -- there's no single "winning" row for an aggregate value, so this adopts the same arbitrary-but-deterministic convention geckopy's `apply_kcat_list` already uses (`j = 0`, first row).
- Documented the source-attribution convention in the docstring.

Closes raven-gecko-parity#73.

## Test plan
- [x] New unit test `testSelectKcatValueMedianAndMeanCompute_tc0053` in `geckoCoreFunctionTests.m` -- checks both criteria compute the right aggregate and attribute source to the first row (matching the reproducer in the linked issue)
- [x] Full `geckoCoreFunctionTests.m` suite -- 53 passed, 0 failed