### PR TITLE
applyCustomKcats: mode-A rows write ec.source/ec.notes too

### DIFF
--- a/src/geckomat/change_model/applyCustomKcats.m
+++ b/src/geckomat/change_model/applyCustomKcats.m
@@ -131,6 +131,19 @@ if ~model.ec.geckoLight
             rxnIdxs = ismember(ecRxnNoSuffix,rxns);
             rxnToUpdate(rxnIdxs) = 1;
             model.ec.kcat(rxnIdxs) = customKcats.kcat(i);
+
+            % Add note mentioning manual kcat change
+            model.ec.source(rxnIdxs) = {'custom'};
+            if isfield(customKcats,'notes')
+                matchedIdxs = find(rxnIdxs);
+                for j = 1:numel(matchedIdxs)
+                    if isempty(model.ec.notes{matchedIdxs(j), 1}) && ~isempty(customKcats.notes{i})
+                        model.ec.notes{matchedIdxs(j), 1} = customKcats.notes{i};
+                    else
+                        model.ec.notes{matchedIdxs(j), 1} = [model.ec.notes{matchedIdxs(j), 1} ', ' customKcats.notes{i}];
+                    end
+                end
+            end
         else
             prots = strtrim(strsplit(customKcats.proteins{i}, '+'));
 

--- a/test/unit_tests/geckoCoreFunctionTests.m
+++ b/test/unit_tests/geckoCoreFunctionTests.m
@@ -1936,3 +1936,36 @@ function testSelectKcatValueMedianAndMeanCompute_tc0053(testCase)
     verifyEqual(testCase, meanModel.ec.source, {'a'})
 end
 
+function testApplyCustomKcatsModeAWritesSourceAndNotes_tc0054(testCase)
+    % raven-gecko-parity#51: a mode-A customKcats row (reaction id only,
+    % no protein) updated ec.kcat but left ec.source/ec.notes untouched --
+    % a curator-supplied note was silently discarded, not just left
+    % unset, since customKcats.notes{i} was never even read on that
+    % branch. Fixed to write ec.source='custom' and append ec.notes for
+    % every reaction a mode-A row matches, mirroring the mode-B/C branch
+    % just below it and geckopy's apply_custom_kcats, which already did
+    % this unconditionally.
+    geckoPath = findGECKOroot;
+    adapter = ModelAdapterManager.getAdapter(fullfile(geckoPath,'test','unit_tests','ecTestGEM', 'TestGEMAdapter.m'));
+    model = getGeckoTestModel();
+    ecModel = makeEcModel(model, false, adapter);
+    ecModel = getECfromGEM(ecModel);
+
+    % R3 already carries a real, non-custom kcat, as it would after
+    % selectKcatValue picked a BRENDA-derived value earlier in the
+    % pipeline.
+    r3 = strcmp(ecModel.ec.rxns, 'R3');
+    ecModel.ec.kcat(r3) = 46.5;
+    ecModel.ec.source{r3} = 'brenda';
+
+    customKcats.proteins = {''};
+    customKcats.kcat     = 999;
+    customKcats.rxns     = {'R3'};
+    customKcats.notes    = {'override'};
+
+    test = applyCustomKcats(ecModel, customKcats, adapter);
+    verifyEqual(testCase, test.ec.kcat(r3), 999)
+    verifyEqual(testCase, test.ec.source(r3), {'custom'})
+    verifyEqual(testCase, test.ec.notes(r3), {'override'})
+end
+


### PR DESCRIPTION
## Summary
- A mode-A `customKcats.tsv` row (reaction id only, no protein) updated `ec.kcat` but never touched `ec.source`/`ec.notes` -- the mode-B/C branch a few lines below writes both, but mode-A's own branch returned before reaching that code, so a curator-supplied note was silently discarded rather than just left unset (`customKcats.notes{i}` was never even read on that path).
- Fixed to mirror the mode-B/C write path: stamp `ec.source='custom'` and append `ec.notes` for every reaction a mode-A row matches. Matches geckopy's `apply_custom_kcats`, which already did this unconditionally for all three modes.

Closes raven-gecko-parity#51.

## Test plan
- [x] New unit test `testApplyCustomKcatsModeAWritesSourceAndNotes_tc0054` in `geckoCoreFunctionTests.m` -- verifies a mode-A row now writes both `ec.source='custom'` and the curator's note, using the exact reproducer from the linked issue
- [x] Full `geckoCoreFunctionTests.m` suite -- 54 passed, 0 failed