### PR TITLE
docs: remove cross-language and code-history commentary

### DIFF
--- a/src/geckomat/change_model/getReactionsFromEnzyme.m
+++ b/src/geckomat/change_model/getReactionsFromEnzyme.m
@@ -24,9 +24,8 @@ function [rxns, kcat, idx, rxnNames, grRules] = getReactionsFromEnzyme(ecModel,p
 % Notes
 % -----
 % An unmatched proteinId is not an error: all five outputs are returned
-% empty, with no warning. geckopy's get_reactions_from_enzyme matches
-% this function's case-insensitive matching, but deliberately raises
-% instead of returning empty on an unmatched id.
+% empty, with no warning. Matching against ecModel.ec.enzymes is
+% case-insensitive.
 %
 % Examples
 % --------

--- a/src/geckomat/gather_kcats/fuzzyKcatMatching.m
+++ b/src/geckomat/gather_kcats/fuzzyKcatMatching.m
@@ -141,7 +141,7 @@ kcats = zeros(length(eccodes),1);
 mM = length(eccodes);
 
 %Create empty kcatInfo
-%Legacy, no longer given as output, rather used to construct
+%Not returned as an output; used only internally to construct
 %kcatList.wildcardLvl and kcatList.origin.
 kcatInfo.info.org_s   = zeros(mM,1);
 kcatInfo.info.rest_s  = zeros(mM,1);
@@ -429,10 +429,11 @@ if wild
         % startsWith, not contains: EC is a truncated prefix like '1.' (everything
         % before the first wildcard dash), and an anchored match is what the
         % non-optimized branch below already does (strfind(...)==1). contains()
-        % matches that same '1.' substring anywhere in the string, not just at the
-        % start -- '4.2.1.1' contains '1.' between its third and fourth levels, so a
-        % '1.-.-.-' wildcard query for enzyme class 1 was also matching entries from
-        % unrelated classes whose EC code happened to contain the same two characters.
+        % would match that same '1.' substring anywhere in the string, not just at
+        % the start -- '4.2.1.1' contains '1.' between its third and fourth levels,
+        % so a '1.-.-.-' wildcard query for enzyme class 1 would also match entries
+        % from unrelated classes whose EC code happens to contain the same two
+        % characters.
         X = find(startsWith(ECIndexIds, EC));
         for j = 1:length(X)
             EC_indexes = [EC_indexes,EcIndexIndices{X(j)}];

--- a/src/geckomat/get_enzyme_data/loadBRENDAdata.m
+++ b/src/geckomat/get_enzyme_data/loadBRENDAdata.m
@@ -8,10 +8,8 @@ function [KCATcell, SAcell] = loadBRENDAdata(varargin)
 % molecular weights).
 %
 % kcat.tsv and sa.tsv each carry both a max and a median aggregate per
-% (EC, substrate, organism) triple; only the max column is used here. The
-% three files are produced by the `geckopy brenda-refresh` CLI (see geckopy's
-% databases.brenda_loader for the Python-side reader of the same files) and
-% each starts with a `#`-prefixed release-version line followed by a
+% (EC, substrate, organism) triple; only the max column is used here. Each
+% file starts with a `#`-prefixed release-version line followed by a
 % tab-delimited column header, both skipped on read.
 %
 % Name-Value Arguments
@@ -58,7 +56,7 @@ MW_file        = fullfile(basePath,'mw.tsv');
 %substrate-level aggregation choice): ec_code, substrate, organism, value,
 %n, references.
 KCATcell      = openDataFile(KCAT_file,1,'%q %q %q %f %f %f %q',4);
-scalingFactor = 1/60;    %[umol/min/mg] -> [mmol/s/g]    Old: 60 [umol/min/mg] -> [mmol/h/g]
+scalingFactor = 1/60;    %[umol/min/mg] -> [mmol/s/g]
 SA            = openDataFile(SA_file,scalingFactor,'%q %q %q %f %f %f %q',4);
 scalingFactor = 1/1000;  %[g/mol] -> [g/mmol]
 MW            = openDataFile(MW_file,scalingFactor,'%q %q %q %f %f %q',4);

--- a/src/geckomat/get_enzyme_data/loadBRENDAdata.m
+++ b/src/geckomat/get_enzyme_data/loadBRENDAdata.m
@@ -96,7 +96,7 @@ for i=1:length(SA{1})
     if ~isempty(org_index)
         SAcell{1} = [SAcell{1};SA{1}(i)];
         SAcell{2} = [SAcell{2};SA{3}(i)];
-        SAcell{3} = [SAcell{3}; SA{4}(i)*mwEC{2}(org_index)]; %[1/hr]
+        SAcell{3} = [SAcell{3}; SA{4}(i)*mwEC{2}(org_index)]; %[1/s]
         SAcell{4} = [SAcell{4}; mwEC{2}(org_index)];
     end
     previousEC = SA{1}(i);

--- a/test/unit_tests/geckoCoreFunctionTests.m
+++ b/test/unit_tests/geckoCoreFunctionTests.m
@@ -542,10 +542,8 @@ function testCalculateFfactor_tc0014(testCase)
     model = getGeckoTestModel();
     ecModel = makeEcModel(model, false, adapter);
 
-    % ecTestGEM ships no data/paxDB.tsv, so with no protData supplied calculateFfactor must
-    % fall back to its documented default of 0.5 --- previously this crashed instead,
-    % since execution fell through past the default-0.5 branch and went on to index into
-    % protData as though it were the struct that branch never produced.
+    % ecTestGEM ships no data/paxDB.tsv, so with no protData supplied
+    % calculateFfactor must fall back to its documented default of 0.5.
     [~, f] = evalc("calculateFfactor(ecModel, [], [], adapter)");
     verifyEqual(testCase,f,0.5)
 end
@@ -594,21 +592,18 @@ function testTestGEMAdapterSpontaneousReactions_tc0016(testCase)
     geckoPath = findGECKOroot;
     adapter = ModelAdapterManager.getAdapter(fullfile(geckoPath,'test','unit_tests','ecTestGEM', 'TestGEMAdapter.m'));
 
-    % getSpontaneousReactions used to reference an undefined variable
-    % (rxns_tsv.rxns) and crash unconditionally whenever called -- this is the
-    % only method that ever calls it (from getStandardKcat.m), so
-    % getStandardKcat could never run against TestGEMAdapter at all.
+    % getStandardKcat.m is the only caller of getSpontaneousReactions; this
+    % verifies it correctly identifies the spontaneous reaction (R4) for the
+    % conventional model.
     model = getGeckoTestModel();
     [spont, spontRxnNames] = adapter.getSpontaneousReactions(model);
     verifyEqual(testCase,find(spont),5)
     verifyEqual(testCase,spontRxnNames,{'R4'})
 
-    % Fixing the undefined variable alone was not enough: the position it set
-    % (spont(5) = true) is only valid for this 7-reaction conventional model.
-    % getStandardKcat's only real caller passes the already-expanded ecModel,
-    % where R4's position among model.rxns has moved -- matching by reaction
-    % id instead of position (mirroring geckopy's own TestGEMAdapter port)
-    % survives that.
+    % getStandardKcat's caller passes the already-expanded ecModel, where
+    % R4's position among model.rxns differs from the conventional model.
+    % getSpontaneousReactions matches by reaction id rather than list
+    % position, so it still correctly identifies R4 here.
     ecModel = makeEcModel(model, false, adapter);
     [spontEc, spontRxnNamesEc] = adapter.getSpontaneousReactions(ecModel);
     verifyEqual(testCase,find(spontEc),find(strcmp(ecModel.rxns,'R4')))
@@ -646,12 +641,8 @@ function testAddNewRxnsToEC_tc0018(testCase)
     ecModel = makeEcModel(model, false, adapter);
 
     % Two new reactions, each with its own isozyme (OR) grRule, added in the same call.
-    % Regression test: addNewRxnsToEC used to lose track of which reaction it was
-    % splitting once more than one needed splitting. It removed (and appended) one entry
-    % at a time while iterating a list of indices computed before any removal, so each
-    % removal shifted the positions of every later entry --- the second (and any further)
-    % reaction's grRule was then read from whatever had shifted into its old position,
-    % rather than its own.
+    % Verifies that each reaction's grRule is matched by reaction id rather
+    % than list position when splitting multiple isozyme reactions in one call.
     newRxns.rxns      = {'RNEWA'; 'RNEWB'};
     newRxns.rxnNames  = {'RNEWA'; 'RNEWB'};
     newRxns.equations = {'m1[c] => e2[e]'; 'm2[c] => e1[e]'};
@@ -1716,7 +1707,7 @@ function testReportEnzymeUsageSkipsOnlyFullyInactiveEnzymes_tc0045(testCase)
 end
 
 
-function testCalculateMWReconciledWithGeckopy_tc0046(testCase)
+function testCalculateMWResidueMassHandling_tc0046(testCase)
     % Verifies calculateMW's residue-mass handling: the water constant is
     % 18.01528; ambiguous residues X and B are computed as the mean of their
     % possible standard residues rather than a fixed constant; residue
@@ -1736,15 +1727,11 @@ function testCalculateMWReconciledWithGeckopy_tc0046(testCase)
 end
 
 function testApplyKcatConstraintsLightSkipsUnassignedIsozyme_tc0047(testCase)
-    % raven-gecko-parity#57: in the light formulation, when one isozyme of
-    % a reaction has no kcat assigned (kcat==0, i.e. an Inf MW/kcat) and
-    % another isozyme does, applyKcatConstraints used to correct the
-    % unassigned isozyme's Inf cost to 0 *before* taking min() across
-    % isozymes, so that fabricated zero always won -- silently leaving
-    % the reaction unconstrained by enzyme usage even though a real kcat
-    % was available on another isozyme. Fixed to drop isozymes with no
-    % usable kcat before selecting the cheapest one, matching geckopy's
-    % apply_kcat_constraints.
+    % In the light formulation, when one isozyme of a reaction has no kcat
+    % assigned (kcat==0, i.e. an Inf MW/kcat) and another isozyme does,
+    % applyKcatConstraints drops the isozyme with no usable kcat before
+    % taking min() across isozymes, so the reaction's enzyme-usage cost is
+    % set by the isozyme that actually has a kcat.
     geckoPath = findGECKOroot;
     adapter = ModelAdapterManager.getAdapter(fullfile(geckoPath,'test','unit_tests','ecTestGEM', 'TestGEMAdapter.m'));
     model = getGeckoTestModel();
@@ -1769,8 +1756,7 @@ end
 
 function testApplyKcatConstraintsLightNoValidIsozymeUncosted_tc0048(testCase)
     % Companion to tc0047: when *every* isozyme of a reaction lacks a
-    % usable kcat, the reaction is left unconstrained (S coefficient 0),
-    % same as before the raven-gecko-parity#57 fix.
+    % usable kcat, the reaction is left unconstrained (S coefficient 0).
     geckoPath = findGECKOroot;
     adapter = ModelAdapterManager.getAdapter(fullfile(geckoPath,'test','unit_tests','ecTestGEM', 'TestGEMAdapter.m'));
     model = getGeckoTestModel();
@@ -1784,12 +1770,10 @@ function testApplyKcatConstraintsLightNoValidIsozymeUncosted_tc0048(testCase)
 end
 
 function testCopyECtoGEMOverwriteNeverErasesWithEmptySource_tc0049(testCase)
-    % raven-gecko-parity#79: overwrite=true used to copy ec.eccodes
-    % verbatim, including empty entries -- so a reaction with a real,
-    % populated eccodes annotation could be silently erased just because
-    % the ec-structure's entry for the same reaction happened to be
-    % empty. Fixed so an empty ec.eccodes source is never copied,
-    % matching geckopy's copy_ec_to_gem.
+    % With overwrite=true, an empty ec.eccodes source entry is never
+    % copied, so a reaction with a real, populated eccodes annotation is
+    % not erased just because the ec-structure's entry for the same
+    % reaction happens to be empty.
     ecModel = struct();
     ecModel.rxns = {'R1';'R2';'R3'};
     ecModel.eccodes = {'1.1.1.1';'';'2.2.2.2'}; % R1, R3 already populated
@@ -1806,8 +1790,7 @@ function testCopyECtoGEMOverwriteNeverErasesWithEmptySource_tc0049(testCase)
 end
 
 function testCopyECtoGEMOverwriteFalseStillFillsEmptyEntries_tc0050(testCase)
-    % Sanity check that the overwrite=false path (unchanged by
-    % raven-gecko-parity#79) still fills only empty entries.
+    % Sanity check that the overwrite=false path fills only empty entries.
     ecModel = struct();
     ecModel.rxns = {'R1';'R2'};
     ecModel.eccodes = {'1.1.1.1';''};
@@ -1821,18 +1804,11 @@ function testCopyECtoGEMOverwriteFalseStillFillsEmptyEntries_tc0050(testCase)
 end
 
 function testMakeEcModelSubSystemsMatchModelConvention_tc0051(testCase)
-    % GECKO#412: usage_prot_* and prot_pool_exchange always assigned a
-    % bare-char subSystems entry ('Protein usage'), regardless of whether
-    % the rest of the model used that convention or the nested
-    % cell-array-of-cell-arrays one (the common case for a real GEM).
-    % Reported against a RAVEN release whose addRxns did not reconcile a
-    % resulting bare-char/nested mix, so checkModelStruct rejected it at
-    % save time ("the subSystems field must be a cell array"). Current
-    % RAVEN's addRxns reconciles that mismatch on its own, so this test
-    % cannot reproduce the save-time crash directly; it instead pins down
-    % that makeEcModel itself now always emits a value matching the
-    % model's own convention, rather than relying on addRxns to paper
-    % over a mismatch.
+    % model.subSystems entries can be represented either as a bare char
+    % ('Protein usage') or as a nested cell-array-of-cell-arrays (the
+    % common case for a real GEM). Verifies that makeEcModel assigns
+    % usage_prot_* and prot_pool_exchange a subSystems value matching
+    % whichever convention the rest of the model uses.
     geckoPath = findGECKOroot;
     adapter = ModelAdapterManager.getAdapter(fullfile(geckoPath,'test','unit_tests','ecTestGEM', 'TestGEMAdapter.m'));
     model = getGeckoTestModel();
@@ -1857,23 +1833,15 @@ function testMakeEcModelSubSystemsMatchModelConvention_tc0051(testCase)
 end
 
 function testEcFVAIsozymeSplitReactionUsesExactDiagonalBound_tc0052(testCase)
-    % raven-gecko-parity#72: for a canonical reaction split across isozyme
-    % variants that compete for a shared limiting resource, ecFVA used to
-    % read each variant's row-wise max/min across *every* canonical
-    % group's solve before summing forward and subtracting reverse
-    % variants -- an "envelope" that can combine values from different,
-    % not-necessarily-jointly-feasible flux distributions. Confirmed
-    % empirically here, not just argued from code: R2's two isozymes
-    % (G1+G2 complex, G3 single) share one upstream supply (R1, capped at
-    % 12, the only route to R2 since R3/R4 are blocked); each isozyme can
-    % reach 12 alone, but never jointly past 12. The unfixed ecFVA reports
-    % maxFlux(R2) = 24 -- double what any feasible flux distribution can
-    % attain -- because some *other* canonical group's solve happens to
-    % report R2_EXP_1 near its own max as a non-objective side effect, and
-    % a different group's solve does the same for R2_EXP_2, and the
-    % row-wise reduction sums the two independently. The fixed version
-    % reads each canonical reaction's bound only from its own group's
-    % solve (the "diagonal"), matching geckopy's ec_fva.
+    % For a canonical reaction split across isozyme variants that compete
+    % for a shared limiting resource, ecFVA reads each canonical
+    % reaction's bound only from its own group's solve (the "diagonal"),
+    % rather than combining row-wise max/min values across every
+    % canonical group's solve, which need not be jointly feasible.
+    % R2's two isozymes (G1+G2 complex, G3 single) share one upstream
+    % supply (R1, capped at 12, the only route to R2 since R3/R4 are
+    % blocked); each isozyme can reach 12 alone, but never jointly past
+    % 12, so maxFlux(R2) must be exactly 12.
     geckoPath = findGECKOroot;
     adapter = ModelAdapterManager.getAdapter(fullfile(geckoPath,'test','unit_tests','ecTestGEM', 'TestGEMAdapter.m'));
     model = getGeckoTestModel();
@@ -1900,24 +1868,17 @@ function testEcFVAIsozymeSplitReactionUsesExactDiagonalBound_tc0052(testCase)
 
     % runParallel=false: exercises the plain-for-loop path directly and
     % keeps this test independent of whether Parallel Computing Toolbox
-    % happens to be installed wherever it runs (raven-gecko-parity#72's
-    % follow-up: ecFVA no longer requires it at all).
+    % happens to be installed wherever it runs; ecFVA does not require it.
     [~, maxFlux] = ecFVA(ecModel, model, 'runParallel', false);
     r2 = strcmp(model.rxns, 'R2');
     verifyEqual(testCase, maxFlux(r2), 12, 'AbsTol', 1e-6)
 end
 
 function testSelectKcatValueMedianAndMeanCompute_tc0053(testCase)
-    % raven-gecko-parity#73: criteria='median'/'mean' used to request a
-    % second output from median()/mean(), which -- unlike max()/min() --
-    % are single-output-only builtins; every call crashed with "Too many
-    % output arguments" the moment the loop reached a reaction using
-    % either criteria, including the function's own docstring example.
-    % Fixed to compute the aggregate directly and attribute model.ec.source
-    % to the first matching kcatList row, matching geckopy's
-    % apply_kcat_list (there is no single "winning" row for an aggregate
-    % value, so this is an arbitrary but deterministic convention shared
-    % by both implementations).
+    % criteria='median'/'mean' compute the aggregate of the matching
+    % kcatList rows directly, and attribute model.ec.source to the first
+    % matching row -- there is no single "winning" row for an aggregate
+    % value, so this is an arbitrary but deterministic convention.
     model.ec.rxns   = {'r1'};
     model.ec.kcat   = 0;
     model.ec.source = {''};
@@ -1937,14 +1898,9 @@ function testSelectKcatValueMedianAndMeanCompute_tc0053(testCase)
 end
 
 function testApplyCustomKcatsModeAWritesSourceAndNotes_tc0054(testCase)
-    % raven-gecko-parity#51: a mode-A customKcats row (reaction id only,
-    % no protein) updated ec.kcat but left ec.source/ec.notes untouched --
-    % a curator-supplied note was silently discarded, not just left
-    % unset, since customKcats.notes{i} was never even read on that
-    % branch. Fixed to write ec.source='custom' and append ec.notes for
-    % every reaction a mode-A row matches, mirroring the mode-B/C branch
-    % just below it and geckopy's apply_custom_kcats, which already did
-    % this unconditionally.
+    % A mode-A customKcats row (reaction id only, no protein) writes
+    % ec.source='custom' and appends ec.notes for every reaction it
+    % matches, mirroring the mode-B/C branch just below it.
     geckoPath = findGECKOroot;
     adapter = ModelAdapterManager.getAdapter(fullfile(geckoPath,'test','unit_tests','ecTestGEM', 'TestGEMAdapter.m'));
     model = getGeckoTestModel();

--- a/tutorials/full_ecModel/protocol.m
+++ b/tutorials/full_ecModel/protocol.m
@@ -280,11 +280,12 @@ ecModel = setParam(ecModel,'obj','r_4041',1);
 ecModel = setProtPoolSize(ecModel);
 
 [ecModel_notUsed, tunedKcats] = sensitivityTuning(ecModel);
-% ===>  The Bayesian kcat tuning function, based on the approach introduced
-%       in the DLKcat paper, is the recommended alternative to the
-%       step-wise sensitivity tuning shown below; the step-wise code is
-%       kept here for the tutorial, but you are encouraged to try out the
-%       Bayesian ABC-SMC functionality.
+% ===>  Since GECKO 3.3.0
+%       The Bayesian kcat tuning function as introduced in the DLKcat paper
+%       has been refactored for GECKO. For legacy purposes, the code for
+%       step-wise sensitivity tuning is still shown here as part of the
+%       tutorial, but you are encouraged to try out the Bayesian ABC-SMC
+%       functionality. 
 %
 %       The bayesianSensitivityTuning function estimates kcat values
 %       using Approximate Bayesian Computation Sequential Monte Carlo
@@ -375,17 +376,31 @@ ecModel = constrainEnzConcs(ecModel);
 
 % STEP 58 Update protein pool
 %
-% ==>  All protein usage reactions draw from the protein pool, both for
-%      proteins with and without concentration constraints. Use
-%      setProtPoolSize to set the protein pool exchange with
-%      condition-specific total protein content.
+% ==> Since GECKO 3.2.0:
+%     All protein usage reactions draw from the protein pool, both for
+%     proteins with and without concentration constraints. As a
+%     consequence, updateProtPool has become obsolete. To set the protein
+%     pool exchange with condition-specific total protein content, use
+%     setProtPoolSize instead. For more explanation, see
+%     https://github.com/SysBioChalmers/GECKO/issues/375
 %
-%      See STEP 32 for considerations about the f-factor. Here, we can
-%      recalculate the f-factor based on the proteomics dataset.
+%     See STEP 32 for considerations about the f-factor. Here, we can
+%     recalculate the f-factor based on the proteomics dataset.
 
 f = calculateFfactor(ecModel,'protData',protData);
 fluxData = loadFluxData();
 ecModel = setProtPoolSize(ecModel,'Ptot',fluxData.Ptot(1),'f',f);
+
+% ==> Before GECKO 3.2.0:
+%     The legacy code is still shown here, but should not be run. The
+%     protein pool reaction will be constraint by the remaining, unmeasured
+%     enzyme content. This is calculated by subtracting the sum of
+%     ecModel.ec.concs from the condition-specific total protein content.
+%     The latter is stored together with the flux data that otherwise will
+%     be used in STEP 59.
+%
+%     fluxData = loadFluxData();
+%     ecModel = updateProtPool(ecModel,fluxData.Ptot(1));
 
 % STEP 59-63 Load flux data
 % Matching the proteomics sample(s), condition-specific flux data needs to

--- a/tutorials/full_ecModel/protocol.m
+++ b/tutorials/full_ecModel/protocol.m
@@ -280,12 +280,11 @@ ecModel = setParam(ecModel,'obj','r_4041',1);
 ecModel = setProtPoolSize(ecModel);
 
 [ecModel_notUsed, tunedKcats] = sensitivityTuning(ecModel);
-% ===>  Since GECKO 3.3.0
-%       The Bayesian kcat tuning function as introduced in the DLKcat paper
-%       has been refactored for GECKO. For legacy purposes, the code for
-%       step-wise sensitivity tuning is still shown here as part of the
-%       tutorial, but you are encouraged to try out the Bayesian ABC-SMC
-%       functionality. 
+% ===>  The Bayesian kcat tuning function, based on the approach introduced
+%       in the DLKcat paper, is the recommended alternative to the
+%       step-wise sensitivity tuning shown below; the step-wise code is
+%       kept here for the tutorial, but you are encouraged to try out the
+%       Bayesian ABC-SMC functionality.
 %
 %       The bayesianSensitivityTuning function estimates kcat values
 %       using Approximate Bayesian Computation Sequential Monte Carlo
@@ -376,31 +375,17 @@ ecModel = constrainEnzConcs(ecModel);
 
 % STEP 58 Update protein pool
 %
-% ==> Since GECKO 3.2.0:
-%     All protein usage reactions draw from the protein pool, both for
-%     proteins with and without concentration constraints. As a
-%     consequence, updateProtPool has become obsolete. To set the protein
-%     pool exchange with condition-specific total protein content, use
-%     setProtPoolSize instead. For more explanation, see
-%     https://github.com/SysBioChalmers/GECKO/issues/375
+% ==>  All protein usage reactions draw from the protein pool, both for
+%      proteins with and without concentration constraints. Use
+%      setProtPoolSize to set the protein pool exchange with
+%      condition-specific total protein content.
 %
-%     See STEP 32 for considerations about the f-factor. Here, we can
-%     recalculate the f-factor based on the proteomics dataset.
+%      See STEP 32 for considerations about the f-factor. Here, we can
+%      recalculate the f-factor based on the proteomics dataset.
 
 f = calculateFfactor(ecModel,'protData',protData);
 fluxData = loadFluxData();
 ecModel = setProtPoolSize(ecModel,'Ptot',fluxData.Ptot(1),'f',f);
-
-% ==> Before GECKO 3.2.0:
-%     The legacy code is still shown here, but should not be run. The
-%     protein pool reaction will be constraint by the remaining, unmeasured
-%     enzyme content. This is calculated by subtracting the sum of
-%     ecModel.ec.concs from the condition-specific total protein content.
-%     The latter is stored together with the flux data that otherwise will
-%     be used in STEP 59.
-%
-%     fluxData = loadFluxData();
-%     ecModel = updateProtPool(ecModel,fluxData.Ptot(1));
 
 % STEP 59-63 Load flux data
 % Matching the proteomics sample(s), condition-specific flux data needs to


### PR DESCRIPTION
## Summary
Comments and docstrings described current behavior in comparison to geckopy, and narrated how the code changed over time (issue/PR references, "used to" framing, before/after comparisons). Rewritten to describe only the current MATLAB behavior and its rationale.

- `getReactionsFromEnzyme.m`: dropped the geckopy comparison and issue reference from the Notes docstring, kept the current-behavior facts (empty-on-unmatch, case-insensitive matching).
- `geckoCoreFunctionTests.m`: rewrote test rationale comments (tc0014, tc0016, tc0018, tc0047-tc0054) to describe only what each test currently verifies, with issue citations and "used to be broken" narratives removed. Also renamed `testCalculateMWReconciledWithGeckopy_tc0046` -> `testCalculateMWResidueMassHandling_tc0046` (only the geckopy reference was in the name; the body was already clean). Test logic/assertions untouched throughout.
- `fuzzyKcatMatching.m`: minor rewording, no functional change.
- `loadBRENDAdata.m`: minor rewording (no functional change), **plus a real fix**: the inline comment on the derived SA*MW kcat value said `%[1/hr]`; it's actually `%[1/s]` (SA is scaled to mmol/(s*g), MW to g/mmol, so SA*MW = 1/s). Confirmed against geckopy's `brenda_loader.py`, which computes the identical product and documents it as 1/s. The value itself was always correct -- only the comment was wrong.


## Test plan
- [x] Full `geckoCoreFunctionTests.m` suite, run solo (no concurrent MATLAB processes) — 54 passed, 0 failed. (protocol.m is a tutorial script, not exercised by the test suite.)