### PR TITLE
docs: setKcatForReactions docstring matches its actual ec.source value

### DIFF
--- a/src/change_model/setKcatForReactions.m
+++ b/src/change_model/setKcatForReactions.m
@@ -25,7 +25,7 @@ function ecModel = setKcatForReactions(ecModel,rxnIds,kcat)
 %     ecModel where selected kcat values in ecModel.ec.kcat are changed, but
 %     not yet applied to the S-matrix (will require to run
 %     applyKcatConstraints). ecModel.ec.source for the changed reactions
-%     will read 'from setKcatForReactions'.
+%     will read 'setKcatForReactions'.
 %
 % Examples
 % --------


### PR DESCRIPTION
Found while working SysBioChalmers/raven-gecko-parity#77 (SysBioChalmers/geckopy#47): the docstring says the changed reactions' `ec.source` will read `'from setKcatForReactions'`, but the actual assignment on the last line writes the bare string `'setKcatForReactions'` (no `'from '` prefix). Docstring was stale; fixed to match the real behavior.